### PR TITLE
Embed training visuals in GUI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 torch
 Pillow
 numba
+matplotlib

--- a/synapse/models/redundant_ip.py
+++ b/synapse/models/redundant_ip.py
@@ -21,12 +21,14 @@ from synapsex.image_processing import load_process_shape_image
 class RedundantNeuralIP:
     """Container for multiple ANNs addressable by an ID."""
 
-    def __init__(self, train_data_dir: str | None = None) -> None:
+    def __init__(self, train_data_dir: str | None = None, collect_figures: bool = False) -> None:
         self.ann_map: Dict[int, VirtualANN] = {}
         self.layer_defs: Dict[int, List[int]] = {}
         self.last_result: int | None = None
         self.train_data_dir = train_data_dir
         self._cached_dataset: tuple[np.ndarray, np.ndarray] | None = None
+        self.collect_figures = collect_figures
+        self.figures: List[object] = []
 
     # ------------------------------------------------------------------
     # Assembly interface
@@ -131,7 +133,11 @@ class RedundantNeuralIP:
             print("Training data dimensions do not match ANN configuration.")
             return
 
-        ann.train_model(X, y, epochs=epochs, lr=0.005, batch_size=16)
+        figs = ann.train_model(
+            X, y, epochs=epochs, lr=0.005, batch_size=16, return_figures=self.collect_figures
+        )
+        if self.collect_figures and figs:
+            self.figures.extend(figs)
 
     # ------------------------------------------------------------------
     # INFER_ANN helpers

--- a/synapse/soc.py
+++ b/synapse/soc.py
@@ -8,12 +8,12 @@ from .models.redundant_ip import RedundantNeuralIP
 
 
 class SoC:
-    def __init__(self, train_data_dir: str | None = None):
+    def __init__(self, train_data_dir: str | None = None, collect_figures: bool = False):
         self.memory = WishboneMemory()
         self.pcie_bridge = PCIeBridge()
         self.mmu = MMU()
         self.video_ip = VideoProcIP()
-        self.neural_ip = RedundantNeuralIP(train_data_dir=train_data_dir)
+        self.neural_ip = RedundantNeuralIP(train_data_dir=train_data_dir, collect_figures=collect_figures)
         self.cpu = CPU("CPU1", self.video_ip, self.neural_ip, self.memory, self.mmu)
         self.asm_program = []
         self.label_map = {}


### PR DESCRIPTION
## Summary
- Capture training figures from VirtualANN and expose them via RedundantNeuralIP and SoC.
- Render training graphs, weight images and confusion matrices in GUI tabs using FigureCanvasTkAgg.
- Ensure processed images are saved to a dedicated directory and declare matplotlib dependency.

## Testing
- `python -m py_compile SynapseX.py synapse/soc.py synapse/models/redundant_ip.py synapse/models/virtual_ann.py synapsex/image_processing.py`
- `pip install matplotlib` *(failed: Could not connect to proxy)*


------
https://chatgpt.com/codex/tasks/task_b_688f4fafdfec832784d47c612e03f028