### PR TITLE
Fix training visualization argument mismatch

### DIFF
--- a/synapse/models/virtual_ann.py
+++ b/synapse/models/virtual_ann.py
@@ -87,7 +87,13 @@ class VirtualANN(nn.Module):
         preds_full = self.predict(X)
 
         figs = []
-        fig = self.visualize_training(loss_hist, acc_hist)
+        fig = self.visualize_training(
+            loss_hist,
+            acc_hist,
+            prec_hist,
+            rec_hist,
+            f1_hist,
+        )
         if fig is not None:
             figs.append(fig)
         fig = self.visualize_weights()


### PR DESCRIPTION
## Summary
- Pass all metric histories to VirtualANN.visualize_training to match signature

## Testing
- `python -m py_compile synapse/models/virtual_ann.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688f72069f8483279a24f65738bb291d