### PR TITLE
Fix background artifacts during image rotation

### DIFF
--- a/synapsex/image_processing.py
+++ b/synapsex/image_processing.py
@@ -123,9 +123,16 @@ def load_process_shape_image(
         resample_lanczos = Image.LANCZOS
 
     pil_img = Image.open(path).convert("L")
+    # Rotate around the background color to avoid introducing spurious edges
+    # when the canvas is expanded. Without specifying ``fillcolor`` the newly
+    # exposed corners are filled with black which the edge detector interprets
+    # as strong gradients, resulting in thick square artefacts after rotation.
+    bg_color = pil_img.getpixel((0, 0))
     processed_images = []
     for angle in range(0, 181, 10):
-        rotated = pil_img.rotate(angle, resample=resample_bicubic, expand=True)
+        rotated = pil_img.rotate(
+            angle, resample=resample_bicubic, expand=True, fillcolor=bg_color
+        )
         arr = np.array(rotated, dtype=np.float32)
         edges = canny_edge_detection(arr, canny_low, canny_high)
         edges[0, :] = 0


### PR DESCRIPTION
## Summary
- preserve original background color when rotating images to avoid spurious edge detection

## Testing
- `python -m py_compile synapsex/image_processing.py`
- `python - <<'PY'
from PIL import Image
import numpy as np
import os
angles=[40,80,100]
for angle in angles:
    before=np.array(Image.open(os.path.join('proc_before',f'square_rot{angle}.png')))
    after=np.array(Image.open(os.path.join('proc_after',f'square_rot{angle}.png')))
    print('angle',angle,'before_nonzero',np.count_nonzero(before), 'after_nonzero',np.count_nonzero(after))
PY`


------
https://chatgpt.com/codex/tasks/task_b_688f7e73bde08327a7e123f24946e9c4