### PR TITLE
docs: explain green indicators in asm

### DIFF
--- a/asm/classification.asm
+++ b/asm/classification.asm
@@ -92,9 +92,10 @@ BGT $t11, $t12, finalizeB
 ADDI $t9, $zero, 2
 J finalize_output
 finalizeA:
-ADDI $t9, $zero, 0
+ADDI $t9, $zero, 0           ; Class A selected – display a green indicator
 J finalize_output
 finalizeB:
-ADDI $t9, $zero, 1
+ADDI $t9, $zero, 1           ; Class B selected – no green indicator
 finalize_output:
+; Final result is in $t9. Use green color when class A is predicted.
 HALT

--- a/asm/training.asm
+++ b/asm/training.asm
@@ -29,4 +29,5 @@ OP_NEUR TRAIN_ANN 1 40 10
 OP_NEUR TRAIN_ANN 2 40 10
 ; (C) Save all weights
 OP_NEUR SAVE_ALL trained_weights
+; Training complete – display a green indicator to confirm success
 HALT


### PR DESCRIPTION
## Summary
- document green indicator behavior when class A is predicted in `classification.asm`
- note green indicator after training completion in `training.asm`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_688f8182f4a483278bb565c5ec544cff