### PR TITLE
Refine metrics visualisations

### DIFF
--- a/SynapseX.py
+++ b/SynapseX.py
@@ -36,6 +36,41 @@ except Exception:  # pragma: no cover - fallback for some platforms
 from synapse.soc import SoC
 
 
+class ScrollableNotebook(ttk.Frame):
+    """A ``ttk.Notebook`` with a horizontal scrollbar for overflowing tabs."""
+
+    def __init__(self, master, **kwargs):
+        super().__init__(master)
+        self.canvas = tk.Canvas(self, highlightthickness=0)
+        self.h_scroll = ttk.Scrollbar(self, orient=tk.HORIZONTAL, command=self.canvas.xview)
+        self.canvas.configure(xscrollcommand=self.h_scroll.set)
+        self.notebook = ttk.Notebook(self.canvas, **kwargs)
+        self.canvas.create_window((0, 0), window=self.notebook, anchor="nw")
+        self.canvas.pack(fill=tk.BOTH, expand=1)
+        self.h_scroll.pack(fill=tk.X)
+        self.notebook.bind("<Configure>", self._on_configure)
+
+    def _on_configure(self, _event) -> None:
+        self.canvas.configure(scrollregion=self.canvas.bbox("all"))
+
+    # proxy common notebook methods
+    def add(self, child, **kw):
+        return self.notebook.add(child, **kw)
+
+    def tabs(self):
+        return self.notebook.tabs()
+
+    def select(self, tab=None):
+        return self.notebook.select(tab)
+
+    def nametowidget(self, name):
+        return self.notebook.nametowidget(name)
+
+    def bind(self, sequence=None, func=None, add=None):
+        return self.notebook.bind(sequence, func, add)
+
+
+
 def load_asm_file(path: str | Path) -> list[str]:
     """Read an assembly file and return a list of lines."""
     with open(path, "r", encoding="utf-8") as f:
@@ -97,7 +132,7 @@ class SynapseXGUI(tk.Tk):
         self.asm_frame.columnconfigure(0, weight=1)
         left_paned.add(self.asm_frame, weight=3)
 
-        self.results_nb = ttk.Notebook(left_paned)
+        self.results_nb = ScrollableNotebook(left_paned)
         left_paned.add(self.results_nb, weight=2)
         self.network_tabs: dict[str, ttk.Notebook] = {}
 
@@ -176,7 +211,8 @@ class SynapseXGUI(tk.Tk):
         if not path:
             return
         processed_dir = Path.cwd() / "processed"
-        processed = load_process_shape_image(path, out_dir=processed_dir)[0]
+        processed_imgs = load_process_shape_image(path, out_dir=processed_dir, save=True)
+        processed = processed_imgs[0]
         soc = SoC()
         base_addr = 0x5000
         for i, val in enumerate(processed):
@@ -190,7 +226,7 @@ class SynapseXGUI(tk.Tk):
         out = buf.getvalue()
         result = soc.cpu.get_reg("$t9")
         if "Classification" not in self.network_tabs:
-            sub_nb = ttk.Notebook(self.results_nb)
+            sub_nb = ScrollableNotebook(self.results_nb)
             self.results_nb.add(sub_nb, text="Classification")
             self.network_tabs["Classification"] = sub_nb
         sub_nb = self.network_tabs["Classification"]
@@ -198,6 +234,14 @@ class SynapseXGUI(tk.Tk):
         text.insert(tk.END, out + f"\nPredicted class: {result}\n")
         text.config(state="disabled")
         sub_nb.add(text, text=f"Run {len(sub_nb.tabs())+1}")
+
+        img_arr = (processed.reshape(28, 28) * 255).astype(np.uint8)
+        proc_photo = ImageTk.PhotoImage(Image.fromarray(img_arr))
+        img_lbl = ttk.Label(sub_nb, image=proc_photo)
+        img_lbl.image = proc_photo
+        self._figure_images.append(proc_photo)
+        sub_nb.add(img_lbl, text="Processed")
+
         sub_nb.select(text)
         self.results_nb.select(sub_nb)
 
@@ -206,7 +250,9 @@ class SynapseXGUI(tk.Tk):
         if not current:
             return
         widget = self.nametowidget(current)
-        if isinstance(widget, ttk.Notebook):
+        if isinstance(widget, ScrollableNotebook):
+            sub_widget = widget.nametowidget(widget.select())
+        elif isinstance(widget, ttk.Notebook):
             sub_widget = widget.nametowidget(widget.select())
         else:
             sub_widget = widget
@@ -262,7 +308,7 @@ class SynapseXGUI(tk.Tk):
         out = buf.getvalue()
         net_name = asm_path.stem
         if net_name not in self.network_tabs:
-            sub_nb = ttk.Notebook(self.results_nb)
+            sub_nb = ScrollableNotebook(self.results_nb)
             self.results_nb.add(sub_nb, text=net_name)
             self.network_tabs[net_name] = sub_nb
         sub_nb = self.network_tabs[net_name]

--- a/synapse/models/redundant_ip.py
+++ b/synapse/models/redundant_ip.py
@@ -112,7 +112,7 @@ class RedundantNeuralIP:
                     if letter not in letter2label:
                         continue
                     processed = load_process_shape_image(
-                        str(img_path), out_dir=Path(self.train_data_dir) / "processed"
+                        str(img_path), out_dir=Path(self.train_data_dir) / "processed", save=True
                     )
                     X_list.append(processed[0])
                     y_list.append(letter2label[letter])

--- a/synapse/models/virtual_ann.py
+++ b/synapse/models/virtual_ann.py
@@ -99,7 +99,7 @@ class VirtualANN(nn.Module):
         fig = self.visualize_weights()
         if fig is not None:
             figs.append(fig)
-        fig = self.visualize_confusion_matrix(y, preds_full, self.layer_sizes[-1])
+        fig = self.visualize_confusion_matrix(y, preds_full)
         if fig is not None:
             figs.append(fig)
 
@@ -125,25 +125,28 @@ class VirtualANN(nn.Module):
     # Visualisation helpers
     # ------------------------------------------------------------------
     def visualize_training(self, loss_hist, acc_hist, prec_hist, rec_hist, f1_hist):
-        """Plot training loss and evaluation metrics."""
+        """Plot training loss and evaluation metrics in separate subplots."""
         if not loss_hist:
             return None
         epochs = range(1, len(loss_hist) + 1)
-        fig, ax1 = plt.subplots()
-        ax1.set_xlabel("Epoch")
-        ax1.set_ylabel("Loss", color="tab:red")
-        ax1.plot(epochs, loss_hist, color="tab:red", label="Loss")
-        ax1.tick_params(axis="y", labelcolor="tab:red")
-        ax2 = ax1.twinx()
-        ax2.set_ylabel("Score")
-        ax2.plot(epochs, acc_hist, label="Accuracy", color="tab:blue")
-        ax2.plot(epochs, prec_hist, label="Precision", color="tab:orange")
-        ax2.plot(epochs, rec_hist, label="Recall", color="tab:green")
-        ax2.plot(epochs, f1_hist, label="F1", color="tab:purple")
-        ax2.tick_params(axis="y")
-        ax2.legend(loc="lower right")
+        fig, axes = plt.subplots(5, 1, figsize=(8, 12), sharex=True)
+
+        axes[0].plot(epochs, loss_hist, color="tab:red")
+        axes[0].set_ylabel("Loss")
+        axes[0].set_title("Training Progress")
+
+        metrics = [
+            (acc_hist, "Accuracy", "tab:blue"),
+            (prec_hist, "Precision", "tab:orange"),
+            (rec_hist, "Recall", "tab:green"),
+            (f1_hist, "F1 Score", "tab:purple"),
+        ]
+        for ax, (hist, label, color) in zip(axes[1:], metrics):
+            ax.plot(epochs, hist, color=color)
+            ax.set_ylabel(label)
+
+        axes[-1].set_xlabel("Epoch")
         fig.tight_layout()
-        plt.title("Training Progress")
         return fig
 
     def visualize_weights(self):
@@ -171,22 +174,33 @@ class VirtualANN(nn.Module):
         ax.axis("off")
         return fig
 
-    def visualize_confusion_matrix(self, y_true, y_pred, num_classes):
-        cm = np.zeros((num_classes, num_classes), dtype=int)
+    def visualize_confusion_matrix(self, y_true, y_pred):
+        """Visualise binary confusion matrix labelled with TN/FP/FN/TP."""
+        cm = np.zeros((2, 2), dtype=int)
         for t, p in zip(y_true, y_pred):
-            cm[t, p] += 1
+            if t == 1 and p == 1:
+                cm[1, 1] += 1  # TP
+            elif t == 1 and p == 0:
+                cm[1, 0] += 1  # FN
+            elif t == 0 and p == 1:
+                cm[0, 1] += 1  # FP
+            else:
+                cm[0, 0] += 1  # TN
         print("Confusion matrix:\n", cm)
         fig, ax = plt.subplots()
         im = ax.imshow(cm, cmap=plt.cm.Blues)
         fig.colorbar(im, ax=ax)
         ax.set_xlabel("Predicted")
         ax.set_ylabel("Actual")
-        ax.set_xticks(range(num_classes))
-        ax.set_yticks(range(num_classes))
+        ax.set_xticks([0, 1])
+        ax.set_yticks([0, 1])
+        ax.set_xticklabels(["Negative", "Positive"])
+        ax.set_yticklabels(["Negative", "Positive"])
         ax.set_title("Confusion Matrix")
-        for i in range(num_classes):
-            for j in range(num_classes):
-                ax.text(j, i, cm[i, j], ha="center", va="center", color="black")
+        labels = [["TN", "FP"], ["FN", "TP"]]
+        for i in range(2):
+            for j in range(2):
+                ax.text(j, i, f"{labels[i][j]}: {cm[i, j]}", ha="center", va="center", color="black")
         plt.tight_layout()
         return fig
 


### PR DESCRIPTION
## Summary
- split training progress into dedicated subplots for loss, accuracy, precision, recall and F1 score
- display binary confusion matrix with TN/FP/FN/TP labels
- provide horizontally scrollable result tabs to handle many outputs
- restore saving of processed images and surface a processed preview in the classification tab

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_688f824c160483278ab41f70cc78d592