### PR TITLE
Visualize all layer weights in network

### DIFF
--- a/synapse/models/virtual_ann.py
+++ b/synapse/models/virtual_ann.py
@@ -150,28 +150,48 @@ class VirtualANN(nn.Module):
         return fig
 
     def visualize_weights(self):
-        """Visualise the first layer weights as an image."""
-        first_layer = None
-        for mod in self.net:
-            if isinstance(mod, nn.Linear):
-                first_layer = mod
-                break
-        if first_layer is None:
+        """Visualise the weights of all linear layers.
+
+        Each linear layer of the network is displayed as a small heatmap where
+        every square corresponds to a neuron in that layer.  The numeric value
+        shown in each square is the mean of the neuron's incoming weights.  All
+        layers are placed into a single figure so that the caller can present
+        them on the same tab in the GUI.
+        """
+
+        layers = [mod for mod in self.net if isinstance(mod, nn.Linear)]
+        if not layers:
             return None
-        with torch.no_grad():
-            weights = first_layer.weight.cpu().numpy()
-        avg_w = weights.mean(axis=0)
-        side = int(np.sqrt(avg_w.size))
-        if side * side != avg_w.size:
-            # pad to square for display
-            pad = np.zeros(side * side)
-            pad[: avg_w.size] = avg_w
-            avg_w = pad
-        img = avg_w.reshape(side, side)
-        fig, ax = plt.subplots()
-        ax.imshow(img, cmap="seismic")
-        ax.set_title("First Layer Avg Weights")
-        ax.axis("off")
+
+        n_layers = len(layers)
+        cols = min(4, n_layers)
+        rows = int(np.ceil(n_layers / cols))
+        fig, axes = plt.subplots(rows, cols, figsize=(4 * cols, 4 * rows))
+        axes = np.atleast_1d(axes).flatten()
+
+        for idx, (layer, ax) in enumerate(zip(layers, axes)):
+            with torch.no_grad():
+                weights = layer.weight.cpu().numpy()
+            # compute a single representative value per neuron
+            means = weights.mean(axis=1)
+            side = int(np.ceil(np.sqrt(means.size)))
+            grid = np.full(side * side, np.nan)
+            grid[: means.size] = means
+            grid = grid.reshape(side, side)
+            im = ax.imshow(grid, cmap="seismic")
+            ax.set_title(f"Layer {idx + 1} Weights")
+            ax.axis("off")
+            for i in range(side):
+                for j in range(side):
+                    cell_idx = i * side + j
+                    if cell_idx < means.size:
+                        ax.text(j, i, f"{grid[i, j]:.2f}", ha="center", va="center", color="black")
+
+        # hide any unused axes
+        for ax in axes[n_layers:]:
+            ax.axis("off")
+
+        fig.tight_layout()
         return fig
 
     def visualize_confusion_matrix(self, y_true, y_pred):


### PR DESCRIPTION
## Summary
- Visualize weights for every linear layer in a single figure
- Annotate each neuron's square with the mean of its incoming weights for clearer insight

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_688f86c221948327991812b90007fd08