### PR TITLE
Visualize weights for all network layers

### DIFF
--- a/SynapseX.py
+++ b/SynapseX.py
@@ -273,17 +273,30 @@ class SynapseXGUI(tk.Tk):
         sub_nb.select(text)
         self.results_nb.select(sub_nb)
 
-        # add generated figures as notebook tabs
+        # add generated figures as notebook tabs with scrollbars
         for fig in soc.neural_ip.last_figures:
             buf_img = io.BytesIO()
             fig.savefig(buf_img, format="png")
             buf_img.seek(0)
             image = Image.open(buf_img)
             photo = ImageTk.PhotoImage(image)
-            lbl = ttk.Label(self.results_nb, image=photo)
-            lbl.image = photo
+
+            frame = ttk.Frame(self.results_nb)
+            canvas = tk.Canvas(frame, width=min(800, image.width), height=min(600, image.height))
+            hbar = ttk.Scrollbar(frame, orient=tk.HORIZONTAL, command=canvas.xview)
+            vbar = ttk.Scrollbar(frame, orient=tk.VERTICAL, command=canvas.yview)
+            canvas.configure(xscrollcommand=hbar.set, yscrollcommand=vbar.set)
+            canvas.create_image(0, 0, image=photo, anchor="nw")
+            canvas.configure(scrollregion=(0, 0, image.width, image.height))
+
+            canvas.grid(row=0, column=0, sticky="nsew")
+            vbar.grid(row=0, column=1, sticky="ns")
+            hbar.grid(row=1, column=0, sticky="ew")
+            frame.rowconfigure(0, weight=1)
+            frame.columnconfigure(0, weight=1)
+
             self._figure_images.append(photo)
-            self.results_nb.add(lbl, text=f"Fig {len(self.results_nb.tabs())}")
+            self.results_nb.add(frame, text=f"Fig {len(self.results_nb.tabs()) + 1}")
             plt.close(fig)
 
 

--- a/synapse/models/virtual_ann.py
+++ b/synapse/models/virtual_ann.py
@@ -150,28 +150,25 @@ class VirtualANN(nn.Module):
         return fig
 
     def visualize_weights(self):
-        """Visualise the first layer weights as an image."""
-        first_layer = None
-        for mod in self.net:
-            if isinstance(mod, nn.Linear):
-                first_layer = mod
-                break
-        if first_layer is None:
+        """Visualise all linear layer weights."""
+        linears = [mod for mod in self.net if isinstance(mod, nn.Linear)]
+        if not linears:
             return None
-        with torch.no_grad():
-            weights = first_layer.weight.cpu().numpy()
-        avg_w = weights.mean(axis=0)
-        side = int(np.sqrt(avg_w.size))
-        if side * side != avg_w.size:
-            # pad to square for display
-            pad = np.zeros(side * side)
-            pad[: avg_w.size] = avg_w
-            avg_w = pad
-        img = avg_w.reshape(side, side)
-        fig, ax = plt.subplots()
-        ax.imshow(img, cmap="seismic")
-        ax.set_title("First Layer Avg Weights")
-        ax.axis("off")
+
+        cols = len(linears)
+        fig, axes = plt.subplots(1, cols, figsize=(4 * cols, 4))
+        if cols == 1:
+            axes = [axes]
+
+        for idx, (layer, ax) in enumerate(zip(linears, axes)):
+            with torch.no_grad():
+                weights = layer.weight.cpu().numpy()
+            ax.imshow(weights, cmap="seismic")
+            ax.set_title(f"Layer {idx + 1} Weights")
+            ax.set_xticks([])
+            ax.set_yticks([])
+
+        fig.tight_layout()
         return fig
 
     def visualize_confusion_matrix(self, y_true, y_pred):


### PR DESCRIPTION
## Summary
- retain original heatmap-style weight plots for each linear layer without numeric overlays
- embed generated figures in scrollable canvases so wide plots remain viewable

## Testing
- `python -m py_compile synapse/models/virtual_ann.py SynapseX.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_688f86c221948327991812b90007fd08