### PR TITLE
Add positional embeddings to transformer model

### DIFF
--- a/synapsex/models.py
+++ b/synapsex/models.py
@@ -13,6 +13,9 @@ class TransformerClassifier(nn.Module):
         embed_dim = patch_size * patch_size
         self.patch_embed = nn.Conv2d(1, embed_dim, kernel_size=patch_size, stride=patch_size)
         n_patches = (image_size // patch_size) ** 2
+        # Positional embeddings for each patch
+        self.pos_embed = nn.Parameter(torch.zeros(n_patches, embed_dim))
+        nn.init.normal_(self.pos_embed, std=0.02)
         encoder_layer = nn.TransformerEncoderLayer(d_model=embed_dim, nhead=4, dropout=dropout)
         self.transformer = nn.TransformerEncoder(encoder_layer, num_layers=2)
         self.dropout = nn.Dropout(dropout)
@@ -22,6 +25,7 @@ class TransformerClassifier(nn.Module):
         # x: (batch, 1, H, W)
         x = self.patch_embed(x)  # (batch, embed_dim, H/P, W/P)
         x = x.flatten(2).transpose(1, 2)  # (batch, n_patches, embed_dim)
+        x = x + self.pos_embed  # add positional information
         x = self.transformer(x)  # (batch, n_patches, embed_dim)
         x = x.flatten(1)
         x = self.dropout(x)

--- a/synapsex/neural.py
+++ b/synapsex/neural.py
@@ -48,7 +48,9 @@ class PyTorchANN:
         torch.save(self.model.state_dict(), path)
 
     def load(self, path: str) -> None:
-        self.model.load_state_dict(torch.load(path, map_location="cpu"))
+        state = torch.load(path, map_location="cpu")
+        # Allow loading models saved without positional embeddings
+        self.model.load_state_dict(state, strict=False)
 
 
 class RedundantNeuralIP:


### PR DESCRIPTION
## Summary
- add learnable positional embeddings for image patches and apply them before transformer encoding
- allow loading older checkpoints without positional embeddings

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_688fe3351fcc8327a1da64ea574fa647