### PR TITLE
Avoid rotation during classification

### DIFF
--- a/SynapseX.py
+++ b/SynapseX.py
@@ -176,7 +176,7 @@ class SynapseXGUI(tk.Tk):
         if not path:
             return
         processed_dir = Path.cwd() / "processed"
-        processed = load_process_shape_image(path, out_dir=processed_dir)[0]
+        processed = load_process_shape_image(path, out_dir=processed_dir, angles=[0])[0]
         soc = SoC()
         base_addr = 0x5000
         for i, val in enumerate(processed):

--- a/synapse/models/redundant_ip.py
+++ b/synapse/models/redundant_ip.py
@@ -114,8 +114,8 @@ class RedundantNeuralIP:
                     processed = load_process_shape_image(
                         str(img_path), out_dir=Path(self.train_data_dir) / "processed"
                     )
-                    X_list.append(processed[0])
-                    y_list.append(letter2label[letter])
+                    X_list.extend(processed)
+                    y_list.extend([letter2label[letter]] * len(processed))
                 if not X_list:
                     print("No training images found; aborting training.")
                     return

--- a/synapsex/image_processing.py
+++ b/synapsex/image_processing.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 import numpy as np
 from PIL import Image
-from typing import List
+from typing import Iterable, List
 
 
 def gaussian_kernel(size: int = 5, sigma: float = 1.4) -> np.ndarray:
@@ -114,6 +114,7 @@ def load_process_shape_image(
     canny_high: float = 150,
     dilation_iter: int = 1,
     out_dir: str | None = None,
+    angles: Iterable[int] = range(0, 181, 10),
 ) -> List[np.ndarray]:
     try:
         resample_bicubic = Image.Resampling.BICUBIC
@@ -129,7 +130,7 @@ def load_process_shape_image(
     # as strong gradients, resulting in thick square artefacts after rotation.
     bg_color = pil_img.getpixel((0, 0))
     processed_images = []
-    for angle in range(0, 181, 10):
+    for angle in angles:
         rotated = pil_img.rotate(
             angle, resample=resample_bicubic, expand=True, fillcolor=bg_color
         )

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+import numpy as np
+from PIL import Image
+
+sys.path.append(os.getcwd())
+from synapsex.image_processing import load_process_shape_image
+
+def test_load_process_shape_image_angle_control(tmp_path):
+    img = Image.fromarray(np.zeros((10, 10), dtype=np.uint8))
+    path = tmp_path / "test.png"
+    img.save(path)
+    multi = load_process_shape_image(str(path), save=False, angles=[0, 90])
+    single = load_process_shape_image(str(path), save=False, angles=[0])
+    assert len(multi) == 2
+    assert len(single) == 1


### PR DESCRIPTION
## Summary
- Allow explicit angle selection when preprocessing images
- Use only the original angle during classification
- Expand training dataset with all rotated variants and add unit test

## Testing
- `pytest tests/test_image_processing.py::test_load_process_shape_image_angle_control -q`
- `pytest -q` *(fails: RuntimeError: iverilog not installed)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_688ff3023950832782f2b2a7f3f9f4bf