### PR TITLE
Fix mermaid syntax in training flowchart

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ The high‑level flow is shown below:
 flowchart TD
     A[Load & preprocess images] --> B[TensorDataset & DataLoader]
     B --> C{Epoch loop}
-    C --> D[Forward pass]\nCrossEntropy
+    C --> D[Forward pass\\nCrossEntropy]
     D --> E[Backprop & Adam step]
     E --> F[Log metrics]
     F --> C


### PR DESCRIPTION
## Summary
- Correct mermaid syntax in README training flowchart so Forward Pass and CrossEntropy render properly

## Testing
- `pytest` *(fails: iverilog not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6890042f92a8832782b38bea51128daf