### PR TITLE
docs: expand Monte Carlo dropout section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,66 @@ SynapseX bundles several neural architectures and ensemble techniques:
 - **Majority voting.** Predictions from several ANNs are combined to
   yield a robust final prediction.
 
+### Monte Carlo Dropout and Bayesian Inference (Plain English)
+
+Monte Carlo (MC) dropout is like asking the same neural network to guess many
+times while randomly forgetting parts of itself. Each time the network makes a
+prediction, some neurons are "dropped" at random so the network behaves a bit
+different. By averaging all of these guesses we get a more reliable final
+answer.
+
+Bayesian inference is a fancy term for reasoning about the uncertainty of those
+guesses. The many MC dropout runs act like sampling from different plausible
+networks. If the guesses agree, we are confident; if they vary widely, the model
+is unsure. This cheap trick gives us an approximation of true Bayesian
+reasoning without heavy mathematics.
+
+#### Step-by-step
+
+1. **Train with dropout** – build your model with dropout layers and train as
+   usual. Dropout randomly zeros some activations so the model does not rely on
+   any single neuron.
+2. **Keep dropout on for inference** – when you want a prediction, *do not*
+   disable dropout.
+3. **Run multiple forward passes** – feed the same input \(x\) through the
+   network \(T\) times. Each pass uses a different random dropout mask, producing
+   predictions \(f_{\theta_t}(x)\).
+4. **Aggregate the predictions** – average the outputs to get a final guess and
+   measure how far individual predictions stray from that average to estimate
+   uncertainty.
+
+```mermaid
+flowchart TD
+    X[Input x] --> P1[Pass 1\nDropout ON]
+    X --> P2[Pass 2\nDropout ON]
+    X --> PT[Pass T\nDropout ON]
+    P1 & P2 & PT --> C[Collect predictions]
+    C --> M[Mean & variance]
+    M --> Y[Prediction +\nuncertainty]
+```
+
+#### Formulas
+
+The averaged prediction and its uncertainty are computed as
+
+$$\hat{y} = \frac{1}{T} \sum_{t=1}^{T} f_{\theta_t}(x)$$
+
+$$\hat{\sigma}^2 = \frac{1}{T} \sum_{t=1}^{T} \left(f_{\theta_t}(x) - \hat{y}\right)^2$$
+
+#### Inputs
+
+- trained network with dropout layers
+- new example \(x\)
+- number of Monte Carlo passes \(T\)
+
+#### Outputs
+
+- mean prediction \(\hat{y}\)
+- uncertainty estimate \(\hat{\sigma}\)
+
+Each dropout mask acts like sampling a different set of weights, giving us a
+lightweight Bayesian approximation with just a single trained model.
+
 ### Principal ANN Topologies
 
 #### ANN0 – Transformer Classifier


### PR DESCRIPTION
## Summary
- expand Monte Carlo dropout docs with step-by-step guide, diagram, formulas, and I/O details for beginners

## Testing
- `pytest tests/test_transformer_classifier.py::test_transformer_classifier_hw_match -q` *(fails: RuntimeError: iverilog not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68900129a7608327876020b0a5019db8