### PR TITLE
feat: stop training once metrics converge

### DIFF
--- a/HYPERPARAMETERS.md
+++ b/HYPERPARAMETERS.md
@@ -8,9 +8,13 @@ SynapseX's machine-learning components are configurable through a set of hyperpa
 |------|---------|-------------|
 | `BATCH_SIZE` | `32` | Number of samples processed in each optimisation step. |
 | `LEARNING_RATE` | `0.001` | Step size used by the Adam optimiser during training. |
-| `EPOCHS` | `10` | Number of passes through the training dataset. |
+| `EPOCHS` | `10` | Minimum number of passes through the training dataset before evaluating stop criteria. |
 | `DROPOUT_RATE` | `0.2` | Dropout probability applied to fully connected layers during training. |
 | `MC_PASSES` | `10` | Stochastic forward passes run during Monte Carlo dropout inference. |
+| `TARGET_ACCURACY` | `0.95` | Training continues until accuracy meets or exceeds this value. |
+| `TARGET_PRECISION` | `0.95` | Training continues until precision meets or exceeds this value. |
+| `TARGET_RECALL` | `0.95` | Training continues until recall meets or exceeds this value. |
+| `TARGET_F1` | `0.95` | Training continues until F1 score meets or exceeds this value. |
 | `LAYER_SIZES` | `[784, 256, 256, 3]` | Example dense network architecture listing neurons per layer. |
 | `IMAGE_SIDE` | `28` | Height and width (in pixels) of input images. |
 | `IMAGE_SIZE` | `784` | Flattened input dimension derived from `IMAGE_SIDE`. |
@@ -30,6 +34,10 @@ The `HyperParameters` dataclass exposes similar knobs for runtime configuration.
 | `image_size` | `28` | Side length of square input images provided to the Transformer classifier. |
 | `dropout` | `0.2` | Dropout probability applied to model layers. |
 | `learning_rate` | `1e-3` | Optimiser step size during training. |
-| `epochs` | `10` | Number of training epochs. |
+| `epochs` | `10` | Minimum number of training epochs before evaluating stop criteria. |
 | `batch_size` | `32` | Mini-batch size for the `DataLoader`. |
 | `mc_dropout_passes` | `10` | Number of forward passes to average when using Monte Carlo dropout. |
+| `target_accuracy` | `0.95` | Training halts once accuracy meets or exceeds this value. |
+| `target_precision` | `0.95` | Training halts once precision meets or exceeds this value. |
+| `target_recall` | `0.95` | Training halts once recall meets or exceeds this value. |
+| `target_f1` | `0.95` | Training halts once F1 score meets or exceeds this value. |

--- a/config/hyperparameters.py
+++ b/config/hyperparameters.py
@@ -3,9 +3,15 @@
 # Training hyperparameters
 BATCH_SIZE = 32
 LEARNING_RATE = 0.001
+# Minimum number of epochs to run before considering early stopping
 EPOCHS = 10
 DROPOUT_RATE = 0.2
 MC_PASSES = 10
+# Training stops once all of these metrics meet or exceed the targets
+TARGET_ACCURACY = 0.95
+TARGET_PRECISION = 0.95
+TARGET_RECALL = 0.95
+TARGET_F1 = 0.95
 
 # Model architecture
 LAYER_SIZES = [784, 256, 256, 3]  # Example architecture for 28x28 input and 3 classes

--- a/synapsex/config.py
+++ b/synapsex/config.py
@@ -5,8 +5,14 @@ class HyperParameters:
     image_size: int = 28
     dropout: float = 0.2
     learning_rate: float = 1e-3
+    # Minimum epochs before early stopping is considered
     epochs: int = 10
     batch_size: int = 32
     mc_dropout_passes: int = 10
+    # Target metrics required to stop training
+    target_accuracy: float = 0.95
+    target_precision: float = 0.95
+    target_recall: float = 0.95
+    target_f1: float = 0.95
 
 hp = HyperParameters()

--- a/synapsex/neural.py
+++ b/synapsex/neural.py
@@ -1,6 +1,7 @@
 import os
 from typing import Dict, Tuple, List
 
+import numpy as np
 import torch
 from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
@@ -20,14 +21,52 @@ class PyTorchANN:
         loader = DataLoader(dataset, batch_size=hp.batch_size, shuffle=True)
         opt = torch.optim.Adam(self.model.parameters(), lr=hp.learning_rate)
         criterion = nn.CrossEntropyLoss()
+        num_classes = self.model.classifier.out_features
         self.model.train()
-        for _ in range(hp.epochs):
+        epoch = 0
+        while True:
+            epoch += 1
+            correct = 0
+            total = 0
+            all_preds: List[int] = []
+            all_true: List[int] = []
             for xb, yb in loader:
                 opt.zero_grad()
                 logits = self.model(xb)
                 loss = criterion(logits, yb)
                 loss.backward()
                 opt.step()
+                preds = logits.argmax(dim=1)
+                correct += (preds == yb).sum().item()
+                total += xb.size(0)
+                all_preds.extend(preds.cpu().numpy().tolist())
+                all_true.extend(yb.cpu().numpy().tolist())
+            acc = correct / total if total else 0.0
+            cm = np.zeros((num_classes, num_classes), dtype=int)
+            for t, p in zip(all_true, all_preds):
+                cm[t, p] += 1
+            precs, recs, f1s = [], [], []
+            for i in range(num_classes):
+                tp = cm[i, i]
+                fp = cm[:, i].sum() - tp
+                fn = cm[i, :].sum() - tp
+                prec = tp / (tp + fp) if (tp + fp) else 0.0
+                rec = tp / (tp + fn) if (tp + fn) else 0.0
+                f1 = 2 * prec * rec / (prec + rec) if (prec + rec) else 0.0
+                precs.append(prec)
+                recs.append(rec)
+                f1s.append(f1)
+            prec = float(np.mean(precs))
+            rec = float(np.mean(recs))
+            f1_val = float(np.mean(f1s))
+            if (
+                epoch >= hp.epochs
+                and acc >= hp.target_accuracy
+                and prec >= hp.target_precision
+                and rec >= hp.target_recall
+                and f1_val >= hp.target_f1
+            ):
+                break
 
     def predict(self, X: torch.Tensor, mc_dropout: bool = False) -> torch.Tensor:
         X = X.unsqueeze(1)


### PR DESCRIPTION
## Summary
- treat `epochs` as a minimum and keep training until accuracy/precision/recall/F1 meet new hyperparameter targets
- extend configuration with target metric thresholds and document them
- implement early stopping based on these metrics for virtual and transformer ANN trainers

## Testing
- `pytest tests/test_transformer_classifier.py::test_transformer_classifier_hw_match -q` *(fails: RuntimeError: iverilog not installed)*
- `apt-get install -y iverilog` *(fails: Unable to locate package iverilog)*

------
https://chatgpt.com/codex/tasks/task_b_6890c2f7b4388327964f660ec5c80e97