### PR TITLE
Add genetic algorithm hyperparameter tuning and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,18 @@ metrics—accuracy, precision, recall and F1—alongside the loss for each epoch
 After inference a confusion matrix is printed and plotted to highlight
 misclassified examples.
 
+## Hyper-parameter Optimisation
+
+To squeeze out extra accuracy, recall, precision and F1 score the training
+helpers incorporate a couple of classic optimisation strategies:
+
+- **Early stopping** halts training when the F1 score fails to improve for a few
+  epochs, reducing the risk of overfitting.
+- **Genetic algorithms** explore different dropout and learning-rate
+  combinations and pick the configuration with the best F1 score.  The compact
+  implementation lives in `synapsex/genetic.py` and can be invoked via
+  `PyTorchANN.tune_hyperparameters_ga` before calling `train`.
+
 ## Assembly Instructions
 
 SynapseX understands a tiny instruction set sufficient for the demos:

--- a/synapsex/genetic.py
+++ b/synapsex/genetic.py
@@ -1,0 +1,110 @@
+"""Simple genetic algorithm for ANN hyper-parameter search.
+
+This module provides a light‑weight genetic algorithm that searches over a
+small space of ``HyperParameters`` in order to maximise the F1 score of a
+``PyTorchANN`` model.  It is intentionally minimal and dependency free so it
+can run in constrained environments.
+
+The search space currently covers the dropout rate and learning rate, two
+hyper‑parameters that strongly influence classification metrics such as
+accuracy, recall and precision.  Each individual in the population represents a
+unique combination of these parameters.  Individuals are evaluated by training a
+model for a few epochs and scoring it on a held‑out validation set.  The best
+performer is returned as the suggested configuration.
+
+The algorithm is purposely small so that projects can quickly experiment with
+genetic optimisation without pulling in heavy third‑party libraries.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import replace
+from typing import List
+
+import torch
+
+from .config import HyperParameters, hp
+
+
+def _random_hyperparameters() -> HyperParameters:
+    """Create a random set of hyper-parameters within sensible bounds."""
+
+    return HyperParameters(
+        image_size=hp.image_size,
+        dropout=random.uniform(0.1, 0.5),
+        learning_rate=10 ** random.uniform(-4, -2),
+        epochs=max(2, hp.epochs // 2),
+        batch_size=hp.batch_size,
+        mc_dropout_passes=hp.mc_dropout_passes,
+    )
+
+
+def _evaluate(hparams: HyperParameters, X_train: torch.Tensor, y_train: torch.Tensor,
+              X_val: torch.Tensor, y_val: torch.Tensor) -> float:
+    """Train a model with ``hparams`` and return the validation F1 score."""
+
+    # Local import to avoid a circular dependency at module load time.
+    from .neural import PyTorchANN
+
+    ann = PyTorchANN(hparams)
+    ann.train(X_train, y_train)
+    metrics = ann.evaluate(X_val, y_val)
+    return metrics["f1"]
+
+
+def genetic_search(X: torch.Tensor, y: torch.Tensor, generations: int = 5,
+                   population_size: int = 8) -> HyperParameters:
+    """Run a tiny genetic algorithm and return the best ``HyperParameters``.
+
+    Parameters
+    ----------
+    X, y:
+        Training data tensors.  They are internally split into a training and
+        validation subset.
+    generations:
+        Number of evolutionary generations to perform.
+    population_size:
+        Number of individuals in each generation's population.
+    """
+
+    # Create a deterministic train/validation split so that all individuals are
+    # evaluated on the same data partition.
+    indices = torch.randperm(len(X))
+    split = int(0.8 * len(X))
+    train_idx = indices[:split]
+    val_idx = indices[split:]
+    X_train, y_train = X[train_idx], y[train_idx]
+    X_val, y_val = X[val_idx], y[val_idx]
+
+    population: List[HyperParameters] = [_random_hyperparameters() for _ in range(population_size)]
+
+    for _ in range(generations):
+        scores = [_evaluate(ind, X_train, y_train, X_val, y_val) for ind in population]
+        # Sort individuals by fitness (descending F1).
+        population = [pop for _, pop in sorted(zip(scores, population), key=lambda p: p[0], reverse=True)]
+        # Elitism: carry over the two best individuals unchanged.
+        new_population: List[HyperParameters] = population[:2]
+
+        # Breed new individuals until the population is replenished.
+        while len(new_population) < population_size:
+            parent1, parent2 = random.sample(population[:4], 2)
+            child_dropout = (parent1.dropout + parent2.dropout) / 2
+            child_lr = (parent1.learning_rate + parent2.learning_rate) / 2
+
+            # Mutation – small random perturbations.
+            child_dropout += random.uniform(-0.05, 0.05)
+            child_dropout = min(max(child_dropout, 0.05), 0.6)
+            child_lr *= 10 ** random.uniform(-0.5, 0.5)
+            child_lr = min(max(child_lr, 1e-4), 1e-2)
+
+            child = replace(parent1, dropout=child_dropout, learning_rate=child_lr)
+            new_population.append(child)
+
+        population = new_population
+
+    # Final evaluation to select the best individual from the last generation.
+    scores = [_evaluate(ind, X_train, y_train, X_val, y_val) for ind in population]
+    best = population[scores.index(max(scores))]
+    return best
+

--- a/synapsex/neural.py
+++ b/synapsex/neural.py
@@ -1,27 +1,43 @@
 import os
-from typing import Dict, Tuple, List
+from typing import Dict, Tuple, List, Optional
 
 import torch
 from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
-from .config import hp
+from .config import hp, HyperParameters
 from .models import TransformerClassifier
 
 
 class PyTorchANN:
-    """Wrapper around a PyTorch model with training and inference helpers."""
+    """Wrapper around a PyTorch model with training and inference helpers.
 
-    def __init__(self):
-        self.model = TransformerClassifier(hp.image_size, num_classes=3, dropout=hp.dropout)
+    Parameters
+    ----------
+    hp_override:
+        Optional ``HyperParameters`` instance.  When provided it overrides the
+        global configuration and allows techniques such as genetic algorithms to
+        propose new hyper-parameter sets.
+    """
 
-    def train(self, X: torch.Tensor, y: torch.Tensor) -> None:
+    def __init__(self, hp_override: Optional[HyperParameters] = None):
+        self.hp = hp_override or hp
+        self.model = TransformerClassifier(self.hp.image_size, num_classes=3, dropout=self.hp.dropout)
+
+    def train(self, X: torch.Tensor, y: torch.Tensor, *, patience: int = 2) -> Dict[str, float]:
+        """Train the network and return evaluation metrics.
+
+        Implements a small form of early stopping based on the F1 score to help
+        improve accuracy, precision and recall."""
+
         dataset = TensorDataset(X.unsqueeze(1), y)
-        loader = DataLoader(dataset, batch_size=hp.batch_size, shuffle=True)
-        opt = torch.optim.Adam(self.model.parameters(), lr=hp.learning_rate)
+        loader = DataLoader(dataset, batch_size=self.hp.batch_size, shuffle=True)
+        opt = torch.optim.Adam(self.model.parameters(), lr=self.hp.learning_rate)
         criterion = nn.CrossEntropyLoss()
         self.model.train()
-        for _ in range(hp.epochs):
+        best_f1 = 0.0
+        stale_epochs = 0
+        for _ in range(self.hp.epochs):
             for xb, yb in loader:
                 opt.zero_grad()
                 logits = self.model(xb)
@@ -29,12 +45,23 @@ class PyTorchANN:
                 loss.backward()
                 opt.step()
 
+            metrics = self.evaluate(X, y)
+            if metrics["f1"] > best_f1:
+                best_f1 = metrics["f1"]
+                stale_epochs = 0
+            else:
+                stale_epochs += 1
+                if stale_epochs >= patience:
+                    break
+
+        return self.evaluate(X, y)
+
     def predict(self, X: torch.Tensor, mc_dropout: bool = False) -> torch.Tensor:
         X = X.unsqueeze(1)
         if mc_dropout:
             self.model.train()  # enable dropout
             preds = []
-            for _ in range(hp.mc_dropout_passes):
+            for _ in range(self.hp.mc_dropout_passes):
                 preds.append(self.model(X))
             mean = torch.stack(preds).mean(0)
             return nn.functional.softmax(mean, dim=1)
@@ -43,6 +70,44 @@ class PyTorchANN:
             with torch.no_grad():
                 logits = self.model(X)
             return nn.functional.softmax(logits, dim=1)
+
+    def evaluate(self, X: torch.Tensor, y: torch.Tensor) -> Dict[str, float]:
+        """Return accuracy, precision, recall and F1 for the given dataset."""
+
+        self.model.eval()
+        with torch.no_grad():
+            logits = self.model(X.unsqueeze(1))
+            preds = logits.argmax(dim=1)
+
+        accuracy = float((preds == y).float().mean().item())
+        num_classes = logits.shape[1]
+        precision_list = []
+        recall_list = []
+        for cls in range(num_classes):
+            tp = ((preds == cls) & (y == cls)).sum().item()
+            fp = ((preds == cls) & (y != cls)).sum().item()
+            fn = ((preds != cls) & (y == cls)).sum().item()
+            precision = tp / (tp + fp + 1e-8)
+            recall = tp / (tp + fn + 1e-8)
+            precision_list.append(precision)
+            recall_list.append(recall)
+        precision = float(sum(precision_list) / num_classes)
+        recall = float(sum(recall_list) / num_classes)
+        f1 = float(2 * precision * recall / (precision + recall + 1e-8))
+        return {"accuracy": accuracy, "precision": precision, "recall": recall, "f1": f1}
+
+    def tune_hyperparameters_ga(self, X: torch.Tensor, y: torch.Tensor, *, generations: int = 5,
+                                population_size: int = 8) -> None:
+        """Use a genetic algorithm to tune the underlying hyper-parameters.
+
+        The best configuration according to F1 score is loaded into this
+        instance's model."""
+
+        from .genetic import genetic_search
+
+        best_hp = genetic_search(X, y, generations=generations, population_size=population_size)
+        self.hp = best_hp
+        self.model = TransformerClassifier(self.hp.image_size, num_classes=3, dropout=self.hp.dropout)
 
     def save(self, path: str) -> None:
         torch.save(self.model.state_dict(), path)


### PR DESCRIPTION
## Summary
- add a lightweight genetic algorithm to optimise ANN hyperparameters
- compute accuracy, precision, recall and F1 with early stopping during training
- document GA hyper-parameter search and early stopping in README

## Testing
- `pytest -q` *(fails: RuntimeError: iverilog not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6891f97254cc8327b56678e15c4053bc