### PR TITLE
Show ANN training plots and predictions

### DIFF
--- a/synapse/models/virtual_ann.py
+++ b/synapse/models/virtual_ann.py
@@ -95,12 +95,15 @@ class VirtualANN(nn.Module):
             f1_hist,
         )
         if fig is not None:
+            fig.show()
             figs.append(fig)
         fig = self.visualize_weights()
         if fig is not None:
+            fig.show()
             figs.append(fig)
         fig = self.visualize_confusion_matrix(y, preds_full)
         if fig is not None:
+            fig.show()
             figs.append(fig)
 
         return figs
@@ -109,7 +112,9 @@ class VirtualANN(nn.Module):
         self.eval()
         with torch.no_grad():
             logits = self(torch.from_numpy(X).float())
-            return torch.argmax(logits, dim=1).cpu().numpy()
+            preds = torch.argmax(logits, dim=1).cpu().numpy()
+            print("Predicted classes:", preds)
+            return preds
 
     def predict_with_uncertainty(self, X: np.ndarray, mc_passes: int = 10):
         self.train()  # enable dropout at inference
@@ -119,6 +124,8 @@ class VirtualANN(nn.Module):
             outputs.append(self(inp).detach().cpu().numpy())
         mean = np.mean(outputs, axis=0)
         var = np.var(outputs, axis=0)
+        preds = np.argmax(mean, axis=1)
+        print("Predicted classes:", preds)
         return mean, var
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Automatically display training metrics, weight plots, and confusion matrix for VirtualANN.
- Print predicted classes for both deterministic and MC-dropout inference methods.

## Testing
- `pytest tests/test_transformer_classifier.py::test_transformer_classifier_hw_match -q` *(fails: iverilog not installed)*


------
https://chatgpt.com/codex/tasks/task_b_6893c1ad749083278ccf0a079c4bec72