### PR TITLE
Add training visuals and CLI classification output

### DIFF
--- a/SynapseX.py
+++ b/SynapseX.py
@@ -332,11 +332,22 @@ def main() -> None:
         if len(sys.argv) < 3:
             print("Usage: python SynapseX.py classify path/to/image.png")
             return
+        image_path = Path(sys.argv[2])
+        if not image_path.is_file():
+            print(f"Image '{image_path}' not found.")
+            return
         soc = SoC()
+        processed_dir = Path.cwd() / "processed"
+        processed = load_process_shape_image(str(image_path), out_dir=processed_dir, angles=[0])[0]
+        base_addr = 0x5000
+        for i, val in enumerate(processed):
+            word = np.frombuffer(np.float32(val).tobytes(), dtype=np.uint32)[0]
+            soc.memory.write(base_addr + i, int(word))
         asm_lines = load_asm_file(Path("asm") / "classification.asm")
         soc.load_assembly(asm_lines)
         soc.run(max_steps=3000)
-        print("\nClassification Phase Completed!")
+        result = soc.cpu.get_reg("$t9")
+        print(f"\nClassification Phase Completed!\nPredicted class: {result}")
     else:
         print("Unknown mode. Use 'train', 'classify' or 'gui'.")
 

--- a/synapse/models/redundant_ip.py
+++ b/synapse/models/redundant_ip.py
@@ -98,7 +98,11 @@ class RedundantNeuralIP:
 
         # Update only the epoch count; GA-tuned learning rate and batch size are preserved
         ann.hp = replace(ann.hp, epochs=epochs)
-        ann.train(torch.from_numpy(X), torch.from_numpy(y))
+        metrics, figs = ann.train(
+            torch.from_numpy(X), torch.from_numpy(y), show_plots=self.show_plots
+        )
+        self.last_figures = figs
+        print(f"ANN {ann_id} metrics: {metrics}")
 
     # ------------------------------------------------------------------
     # INFER_ANN helpers

--- a/synapsex/neural.py
+++ b/synapsex/neural.py
@@ -2,6 +2,10 @@ import os
 from dataclasses import replace
 from typing import Dict, Tuple, List, Optional
 
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
 import torch
 from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
@@ -69,12 +73,14 @@ class PyTorchANN:
         patience: int = 3,
         min_epochs: int = 5,
         val_split: float = 0.2,
+        show_plots: bool = True,
     ) -> Dict[str, float]:
         """Train the network and return evaluation metrics.
 
-        Uses a small validation split for early stopping based on the F1 score
-        and restores the best observed model weights.  ``min_epochs`` guarantees
-        that a few epochs are always run so the network can start learning."""
+        ``show_plots`` controls whether training curves, weight heatmaps and the
+        confusion matrix are displayed once optimisation finishes.  A small
+        validation split drives early stopping based on the F1 score and the
+        best model weights are restored before returning final metrics."""
 
         # Split the data into a deterministic training/validation partition so
         # early stopping decisions are based on unseen samples.
@@ -92,32 +98,63 @@ class PyTorchANN:
         criterion = nn.CrossEntropyLoss()
         self.model.train()
 
+        loss_hist: List[float] = []
+        acc_hist: List[float] = []
+        prec_hist: List[float] = []
+        rec_hist: List[float] = []
+        f1_hist: List[float] = []
+
         best_f1 = -1.0
         best_state: Optional[dict] = None
         stale_epochs = 0
 
-        for epoch in range(self.hp.epochs):
+        for _ in range(self.hp.epochs):
+            epoch_loss = 0.0
+            total = 0
             for xb, yb in train_loader:
                 opt.zero_grad()
                 logits = self.model(xb)
                 loss = criterion(logits, yb)
                 loss.backward()
                 opt.step()
+                epoch_loss += float(loss.item()) * xb.size(0)
+                total += xb.size(0)
 
-            metrics = self.evaluate(val_X, val_y)
-            if metrics["f1"] > best_f1 + 1e-4:
-                best_f1 = metrics["f1"]
+            loss_hist.append(epoch_loss / total if total else 0.0)
+            train_metrics = self.evaluate(train_X, train_y)
+            acc_hist.append(train_metrics["accuracy"])
+            prec_hist.append(train_metrics["precision"])
+            rec_hist.append(train_metrics["recall"])
+            f1_hist.append(train_metrics["f1"])
+
+            val_metrics = self.evaluate(val_X, val_y)
+            if val_metrics["f1"] > best_f1 + 1e-4:
+                best_f1 = val_metrics["f1"]
                 best_state = self.model.state_dict()
                 stale_epochs = 0
             else:
                 stale_epochs += 1
-                if epoch + 1 >= min_epochs and stale_epochs >= patience:
+                if len(loss_hist) >= min_epochs and stale_epochs >= patience:
                     break
 
         if best_state is not None:
             self.model.load_state_dict(best_state)
 
-        return self.evaluate(X, y)
+        final_metrics = self.evaluate(X, y)
+
+        figs: List = []
+        if show_plots:
+            figs = [
+                self._plot_training(loss_hist, acc_hist, prec_hist, rec_hist, f1_hist),
+                self._plot_weights(),
+            ]
+            preds = self.predict(X).argmax(dim=1).cpu().numpy()
+            figs.append(self._plot_confusion_matrix(y.cpu().numpy(), preds))
+            for fig in figs:
+                if fig is not None:
+                    fig.show()
+
+        return final_metrics, figs
 
     def predict(self, X: torch.Tensor, mc_dropout: bool = False) -> torch.Tensor:
         X = self._format_input(X)
@@ -227,6 +264,75 @@ class PyTorchANN:
                 nhead=self.hp.nhead,
             )
             self.model.load_state_dict(state, strict=False)
+
+
+    # ------------------------------------------------------------------
+    # Visualisation helpers
+    # ------------------------------------------------------------------
+    def _plot_training(
+        self,
+        loss_hist: List[float],
+        acc_hist: List[float],
+        prec_hist: List[float],
+        rec_hist: List[float],
+        f1_hist: List[float],
+    ):
+        if not loss_hist:
+            return None
+        epochs = range(1, len(loss_hist) + 1)
+        fig, axes = plt.subplots(5, 1, figsize=(8, 12), sharex=True)
+        axes[0].plot(epochs, loss_hist, color="tab:red")
+        axes[0].set_ylabel("Loss")
+        axes[0].set_title("Training Progress")
+        metrics = [
+            (acc_hist, "Accuracy", "tab:blue"),
+            (prec_hist, "Precision", "tab:orange"),
+            (rec_hist, "Recall", "tab:green"),
+            (f1_hist, "F1 Score", "tab:purple"),
+        ]
+        for ax, (hist, label, color) in zip(axes[1:], metrics):
+            ax.plot(epochs, hist, color=color)
+            ax.set_ylabel(label)
+        axes[-1].set_xlabel("Epoch")
+        fig.tight_layout()
+        return fig
+
+    def _plot_weights(self):
+        linears = [m for m in self.model.modules() if isinstance(m, nn.Linear)]
+        if not linears:
+            return None
+        cols = len(linears)
+        fig, axes = plt.subplots(1, cols, figsize=(4 * cols, 4))
+        if cols == 1:
+            axes = [axes]
+        for idx, (layer, ax) in enumerate(zip(linears, axes)):
+            with torch.no_grad():
+                weights = layer.weight.cpu().numpy()
+            ax.imshow(weights, cmap="seismic")
+            ax.set_title(f"Layer {idx + 1} Weights")
+            ax.set_xticks([])
+            ax.set_yticks([])
+        fig.tight_layout()
+        return fig
+
+    def _plot_confusion_matrix(self, y_true: np.ndarray, y_pred: np.ndarray):
+        num_classes = int(max(y_true.max(), y_pred.max()) + 1)
+        cm = np.zeros((num_classes, num_classes), dtype=int)
+        for t, p in zip(y_true, y_pred):
+            cm[int(t), int(p)] += 1
+        fig, ax = plt.subplots()
+        im = ax.imshow(cm, cmap=plt.cm.Blues)
+        fig.colorbar(im, ax=ax)
+        ax.set_xlabel("Predicted")
+        ax.set_ylabel("Actual")
+        ax.set_xticks(range(num_classes))
+        ax.set_yticks(range(num_classes))
+        ax.set_title("Confusion Matrix")
+        for i in range(num_classes):
+            for j in range(num_classes):
+                ax.text(j, i, str(cm[i, j]), ha="center", va="center", color="black")
+        plt.tight_layout()
+        return fig
 
 
 class RedundantNeuralIP:


### PR DESCRIPTION
## Summary
- Plot loss and evaluation metrics during training and show weight heatmaps and confusion matrix
- Surface ANN training metrics in RedundantNeuralIP and retain generated figures
- Load image data for CLI classification and print predicted class

## Testing
- `pytest -q` *(fails: RuntimeError: iverilog not installed)*
- `sudo apt-get update` *(403 errors: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_6893c1ad749083278ccf0a079c4bec72