### PR TITLE
Add training visuals and CLI classification output

### DIFF
--- a/synapse/models/redundant_ip.py
+++ b/synapse/models/redundant_ip.py
@@ -13,6 +13,8 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Dict, List
 
+import matplotlib.pyplot as plt
+
 import numpy as np
 import torch
 
@@ -25,14 +27,13 @@ from synapsex.image_processing import load_process_shape_image
 class RedundantNeuralIP:
     """Container for multiple ANNs addressable by an ID."""
 
-    def __init__(self, train_data_dir: str | None = None, show_plots: bool = True) -> None:
+    def __init__(self, train_data_dir: str | None = None) -> None:
         self.ann_map: Dict[int, PyTorchANN] = {}
         self.last_result: int | None = None
         self.train_data_dir = train_data_dir
         self._cached_dataset: tuple[np.ndarray, np.ndarray] | None = None
-        self.show_plots = show_plots
-        # figures generated during the last training run (unused for PyTorchANN)
-        self.last_figures: List = []
+        # Figures generated during training keyed by ANN ID
+        self.figures_by_ann: Dict[int, List] = {}
 
     # ------------------------------------------------------------------
     # Assembly interface
@@ -98,7 +99,11 @@ class RedundantNeuralIP:
 
         # Update only the epoch count; GA-tuned learning rate and batch size are preserved
         ann.hp = replace(ann.hp, epochs=epochs)
-        ann.train(torch.from_numpy(X), torch.from_numpy(y))
+        metrics, figs = ann.train(torch.from_numpy(X), torch.from_numpy(y))
+        for old in self.figures_by_ann.get(ann_id, []):
+            plt.close(old)
+        self.figures_by_ann[ann_id] = figs
+        print(f"ANN {ann_id} metrics: {metrics}")
 
     # ------------------------------------------------------------------
     # INFER_ANN helpers

--- a/synapse/soc.py
+++ b/synapse/soc.py
@@ -8,12 +8,12 @@ from .models.redundant_ip import RedundantNeuralIP
 
 
 class SoC:
-    def __init__(self, train_data_dir: str | None = None, show_plots: bool = True):
+    def __init__(self, train_data_dir: str | None = None):
         self.memory = WishboneMemory()
         self.pcie_bridge = PCIeBridge()
         self.mmu = MMU()
         self.video_ip = VideoProcIP()
-        self.neural_ip = RedundantNeuralIP(train_data_dir=train_data_dir, show_plots=show_plots)
+        self.neural_ip = RedundantNeuralIP(train_data_dir=train_data_dir)
         self.cpu = CPU("CPU1", self.video_ip, self.neural_ip, self.memory, self.mmu)
         self.asm_program = []
         self.label_map = {}


### PR DESCRIPTION
## Summary
- Return ANN training figures without opening Matplotlib windows so the GUI can display them in tabs
- Simplify SoC and neural IP setup by removing the `show_plots` flag
- Keep CLI classification reporting the predicted class

## Testing
- `pytest tests/test_transformer_classifier.py::test_transformer_classifier_hw_match -q` *(fails: RuntimeError: iverilog not installed)*
- `sudo apt-get update -y` *(fails: 403  Forbidden [IP: 172.30.2.67 8080])*

------
https://chatgpt.com/codex/tasks/task_b_6893c1ad749083278ccf0a079c4bec72