### PR TITLE
Fix transformer batch layout

### DIFF
--- a/synapsex/models.py
+++ b/synapsex/models.py
@@ -30,7 +30,14 @@ class TransformerClassifier(nn.Module):
         # Positional embeddings for each patch
         self.pos_embed = nn.Parameter(torch.zeros(n_patches, embed_dim))
         nn.init.normal_(self.pos_embed, std=0.02)
-        encoder_layer = nn.TransformerEncoderLayer(d_model=embed_dim, nhead=self.nhead, dropout=dropout)
+        # Use batch_first=True so inputs are (batch, sequence, feature).
+        # This avoids nested tensor warnings and enables better performance.
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=embed_dim,
+            nhead=self.nhead,
+            dropout=dropout,
+            batch_first=True,
+        )
         self.transformer = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
         self.dropout = nn.Dropout(dropout)
         self.head = nn.Linear(n_patches * embed_dim, num_classes)


### PR DESCRIPTION
## Summary
- use batch-first layout for TransformerClassifier to enable nested tensor optimizations and avoid warnings

## Testing
- `pytest` *(fails: RuntimeError: iverilog not installed)*

------
https://chatgpt.com/codex/tasks/task_b_689406fdd49c8327a1f79869810adb8a