### PR TITLE
Fix transformer nested tensor warning and improve training device handling

### DIFF
--- a/synapsex/models.py
+++ b/synapsex/models.py
@@ -30,7 +30,12 @@ class TransformerClassifier(nn.Module):
         # Positional embeddings for each patch
         self.pos_embed = nn.Parameter(torch.zeros(n_patches, embed_dim))
         nn.init.normal_(self.pos_embed, std=0.02)
-        encoder_layer = nn.TransformerEncoderLayer(d_model=embed_dim, nhead=self.nhead, dropout=dropout)
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=embed_dim,
+            nhead=self.nhead,
+            dropout=dropout,
+            batch_first=True,
+        )
         self.transformer = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
         self.dropout = nn.Dropout(dropout)
         self.head = nn.Linear(n_patches * embed_dim, num_classes)

--- a/synapsex/neural.py
+++ b/synapsex/neural.py
@@ -30,13 +30,14 @@ class PyTorchANN:
                 if embed_dim % candidate == 0:
                     self.hp = replace(self.hp, nhead=candidate)
                     break
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.model = TransformerClassifier(
             self.hp.image_size,
             num_classes=3,
             dropout=self.hp.dropout,
             num_layers=self.hp.num_layers,
             nhead=self.hp.nhead,
-        )
+        ).to(self.device)
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -85,7 +86,10 @@ class PyTorchANN:
 
         train_ds = TensorDataset(self._format_input(train_X), train_y)
         train_loader = DataLoader(
-            train_ds, batch_size=self.hp.batch_size, shuffle=True
+            train_ds,
+            batch_size=self.hp.batch_size,
+            shuffle=True,
+            pin_memory=self.device.type == "cuda",
         )
 
         opt = torch.optim.Adam(self.model.parameters(), lr=self.hp.learning_rate)
@@ -98,6 +102,8 @@ class PyTorchANN:
 
         for epoch in range(self.hp.epochs):
             for xb, yb in train_loader:
+                xb = xb.to(self.device, non_blocking=True)
+                yb = yb.to(self.device, non_blocking=True)
                 opt.zero_grad()
                 logits = self.model(xb)
                 loss = criterion(logits, yb)
@@ -107,7 +113,7 @@ class PyTorchANN:
             metrics = self.evaluate(val_X, val_y)
             if metrics["f1"] > best_f1 + 1e-4:
                 best_f1 = metrics["f1"]
-                best_state = self.model.state_dict()
+                best_state = {k: v.cpu() for k, v in self.model.state_dict().items()}
                 stale_epochs = 0
             else:
                 stale_epochs += 1
@@ -120,28 +126,30 @@ class PyTorchANN:
         return self.evaluate(X, y)
 
     def predict(self, X: torch.Tensor, mc_dropout: bool = False) -> torch.Tensor:
-        X = self._format_input(X)
+        X = self._format_input(X).to(self.device)
         if mc_dropout:
             self.model.train()  # enable dropout
             preds = []
             for _ in range(self.hp.mc_dropout_passes):
                 preds.append(self.model(X))
             mean = torch.stack(preds).mean(0)
-            return nn.functional.softmax(mean, dim=1)
+            return nn.functional.softmax(mean, dim=1).cpu()
         else:
             self.model.eval()
             with torch.no_grad():
                 logits = self.model(X)
-            return nn.functional.softmax(logits, dim=1)
+            return nn.functional.softmax(logits, dim=1).cpu()
 
     def evaluate(self, X: torch.Tensor, y: torch.Tensor) -> Dict[str, float]:
         """Return accuracy, precision, recall and F1 for the given dataset."""
 
         self.model.eval()
         with torch.no_grad():
-            logits = self.model(self._format_input(X))
-            preds = logits.argmax(dim=1)
+            logits = self.model(self._format_input(X).to(self.device))
+            preds = logits.argmax(dim=1).cpu()
+        logits = logits.cpu()
 
+        y = y.cpu()
         accuracy = float((preds == y).float().mean().item())
         num_classes = logits.shape[1]
         precision_list = []
@@ -187,7 +195,8 @@ class PyTorchANN:
         self.model = best_ann.model
 
     def save(self, path: str) -> None:
-        torch.save({"state_dict": self.model.state_dict(), "hp": self.hp.__dict__}, path)
+        state = {k: v.cpu() for k, v in self.model.state_dict().items()}
+        torch.save({"state_dict": state, "hp": self.hp.__dict__}, path)
 
     def load(self, path: str) -> None:
         state = torch.load(path, map_location="cpu")
@@ -208,7 +217,7 @@ class PyTorchANN:
                 dropout=self.hp.dropout,
                 num_layers=self.hp.num_layers,
                 nhead=self.hp.nhead,
-            )
+            ).to(self.device)
             # Allow loading models saved without positional embeddings
             self.model.load_state_dict(state["state_dict"], strict=False)
         else:
@@ -225,7 +234,7 @@ class PyTorchANN:
                 dropout=self.hp.dropout,
                 num_layers=self.hp.num_layers,
                 nhead=self.hp.nhead,
-            )
+            ).to(self.device)
             self.model.load_state_dict(state, strict=False)
 
 


### PR DESCRIPTION
## Summary
- enable `batch_first` for transformer encoder to eliminate nested tensor warnings
- add GPU-aware training and evaluation, moving tensors to the appropriate device and saving weights on CPU

## Testing
- `python - <<'PY'
import warnings
warnings.filterwarnings('error')
from synapsex.models import TransformerClassifier
import torch
model = TransformerClassifier(image_size=8)
x = torch.zeros(2,1,8,8)
with torch.no_grad():
    out = model(x)
print(out.shape)
PY`
- `pytest -q` *(fails: RuntimeError: iverilog not installed)*

------
https://chatgpt.com/codex/tasks/task_b_689406fdd49c8327a1f79869810adb8a