### PR TITLE
Display ANN training plots and predicted class

### DIFF
--- a/SynapseX.py
+++ b/SynapseX.py
@@ -260,13 +260,15 @@ class SynapseXGUI(tk.Tk):
             return
         asm_path = Path(sel[0])
         train_dir = self.data_entry.get() or None
-        soc = SoC(train_data_dir=train_dir, show_plots=False)
+        soc = SoC(train_data_dir=train_dir)
         asm_lines = load_asm_file(asm_path)
         soc.load_assembly(asm_lines)
         buf = io.StringIO()
         with redirect_stdout(buf):
             soc.run(max_steps=3000)
         out = buf.getvalue()
+        if soc.neural_ip.last_result is not None:
+            out += f"\nPredicted class: {soc.neural_ip.last_result}\n"
         net_name = asm_path.stem
         if net_name not in self.network_tabs:
             sub_nb = ttk.Notebook(self.results_nb)
@@ -280,31 +282,48 @@ class SynapseXGUI(tk.Tk):
         sub_nb.select(text)
         self.results_nb.select(sub_nb)
 
-        # add generated figures as notebook tabs with scrollbars
-        for fig in soc.neural_ip.last_figures:
-            buf_img = io.BytesIO()
-            fig.savefig(buf_img, format="png")
-            buf_img.seek(0)
-            image = Image.open(buf_img)
-            photo = ImageTk.PhotoImage(image)
+        # Add generated figures for each ANN as tabs within its own notebook
+        tab_titles = ["Metrics", "Weights", "Confusion"]
+        for ann_id, figs in soc.neural_ip.figures_by_ann.items():
+            key = f"ANN {ann_id}"
+            if key not in self.network_tabs:
+                ann_nb = ttk.Notebook(self.results_nb)
+                self.results_nb.add(ann_nb, text=key)
+                self.network_tabs[key] = ann_nb
+            ann_nb = self.network_tabs[key]
+            metrics = soc.neural_ip.metrics_by_ann.get(ann_id)
+            if metrics:
+                metric_txt = ScrolledText(ann_nb, wrap="word", font=("Segoe UI", 10))
+                for name, val in metrics.items():
+                    metric_txt.insert(tk.END, f"{name}: {val:.4f}\n")
+                metric_txt.config(state="disabled")
+                ann_nb.add(metric_txt, text="Summary")
+            for fig, title in zip(figs, tab_titles):
+                buf_img = io.BytesIO()
+                fig.savefig(buf_img, format="png")
+                buf_img.seek(0)
+                image = Image.open(buf_img)
+                photo = ImageTk.PhotoImage(image)
 
-            frame = ttk.Frame(self.results_nb)
-            canvas = tk.Canvas(frame, width=min(800, image.width), height=min(600, image.height))
-            hbar = ttk.Scrollbar(frame, orient=tk.HORIZONTAL, command=canvas.xview)
-            vbar = ttk.Scrollbar(frame, orient=tk.VERTICAL, command=canvas.yview)
-            canvas.configure(xscrollcommand=hbar.set, yscrollcommand=vbar.set)
-            canvas.create_image(0, 0, image=photo, anchor="nw")
-            canvas.configure(scrollregion=(0, 0, image.width, image.height))
+                frame = ttk.Frame(ann_nb)
+                canvas = tk.Canvas(frame, width=min(800, image.width), height=min(600, image.height))
+                hbar = ttk.Scrollbar(frame, orient=tk.HORIZONTAL, command=canvas.xview)
+                vbar = ttk.Scrollbar(frame, orient=tk.VERTICAL, command=canvas.yview)
+                canvas.configure(xscrollcommand=hbar.set, yscrollcommand=vbar.set)
+                canvas.create_image(0, 0, image=photo, anchor="nw")
+                canvas.configure(scrollregion=(0, 0, image.width, image.height))
 
-            canvas.grid(row=0, column=0, sticky="nsew")
-            vbar.grid(row=0, column=1, sticky="ns")
-            hbar.grid(row=1, column=0, sticky="ew")
-            frame.rowconfigure(0, weight=1)
-            frame.columnconfigure(0, weight=1)
+                canvas.grid(row=0, column=0, sticky="nsew")
+                vbar.grid(row=0, column=1, sticky="ns")
+                hbar.grid(row=1, column=0, sticky="ew")
+                frame.rowconfigure(0, weight=1)
+                frame.columnconfigure(0, weight=1)
 
-            self._figure_images.append(photo)
-            self.results_nb.add(frame, text=f"Fig {len(self.results_nb.tabs()) + 1}")
-            plt.close(fig)
+                self._figure_images.append(photo)
+                ann_nb.add(frame, text=title)
+                plt.close(fig)
+        soc.neural_ip.figures_by_ann.clear()
+        soc.neural_ip.metrics_by_ann.clear()
 
 
 def main() -> None:
@@ -332,11 +351,22 @@ def main() -> None:
         if len(sys.argv) < 3:
             print("Usage: python SynapseX.py classify path/to/image.png")
             return
+        image_path = Path(sys.argv[2])
+        if not image_path.is_file():
+            print(f"Image '{image_path}' not found.")
+            return
         soc = SoC()
+        processed_dir = Path.cwd() / "processed"
+        processed = load_process_shape_image(str(image_path), out_dir=processed_dir, angles=[0])[0]
+        base_addr = 0x5000
+        for i, val in enumerate(processed):
+            word = np.frombuffer(np.float32(val).tobytes(), dtype=np.uint32)[0]
+            soc.memory.write(base_addr + i, int(word))
         asm_lines = load_asm_file(Path("asm") / "classification.asm")
         soc.load_assembly(asm_lines)
         soc.run(max_steps=3000)
-        print("\nClassification Phase Completed!")
+        result = soc.cpu.get_reg("$t9")
+        print(f"\nClassification Phase Completed!\nPredicted class: {result}")
     else:
         print("Unknown mode. Use 'train', 'classify' or 'gui'.")
 

--- a/synapse/models/redundant_ip.py
+++ b/synapse/models/redundant_ip.py
@@ -13,6 +13,8 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Dict, List
 
+import matplotlib.pyplot as plt
+
 import numpy as np
 import torch
 
@@ -25,14 +27,14 @@ from synapsex.image_processing import load_process_shape_image
 class RedundantNeuralIP:
     """Container for multiple ANNs addressable by an ID."""
 
-    def __init__(self, train_data_dir: str | None = None, show_plots: bool = True) -> None:
+    def __init__(self, train_data_dir: str | None = None) -> None:
         self.ann_map: Dict[int, PyTorchANN] = {}
         self.last_result: int | None = None
         self.train_data_dir = train_data_dir
         self._cached_dataset: tuple[np.ndarray, np.ndarray] | None = None
-        self.show_plots = show_plots
-        # figures generated during the last training run (unused for PyTorchANN)
-        self.last_figures: List = []
+        # Metrics and figures generated during training keyed by ANN ID
+        self.metrics_by_ann: Dict[int, Dict[str, float]] = {}
+        self.figures_by_ann: Dict[int, List] = {}
 
     # ------------------------------------------------------------------
     # Assembly interface
@@ -98,7 +100,12 @@ class RedundantNeuralIP:
 
         # Update only the epoch count; GA-tuned learning rate and batch size are preserved
         ann.hp = replace(ann.hp, epochs=epochs)
-        ann.train(torch.from_numpy(X), torch.from_numpy(y))
+        metrics, figs = ann.train(torch.from_numpy(X), torch.from_numpy(y))
+        for old in self.figures_by_ann.get(ann_id, []):
+            plt.close(old)
+        self.figures_by_ann[ann_id] = figs
+        self.metrics_by_ann[ann_id] = metrics
+        print(f"ANN {ann_id} metrics: {metrics}")
 
     # ------------------------------------------------------------------
     # INFER_ANN helpers

--- a/synapse/soc.py
+++ b/synapse/soc.py
@@ -8,12 +8,12 @@ from .models.redundant_ip import RedundantNeuralIP
 
 
 class SoC:
-    def __init__(self, train_data_dir: str | None = None, show_plots: bool = True):
+    def __init__(self, train_data_dir: str | None = None):
         self.memory = WishboneMemory()
         self.pcie_bridge = PCIeBridge()
         self.mmu = MMU()
         self.video_ip = VideoProcIP()
-        self.neural_ip = RedundantNeuralIP(train_data_dir=train_data_dir, show_plots=show_plots)
+        self.neural_ip = RedundantNeuralIP(train_data_dir=train_data_dir)
         self.cpu = CPU("CPU1", self.video_ip, self.neural_ip, self.memory, self.mmu)
         self.asm_program = []
         self.label_map = {}

--- a/synapsex/neural.py
+++ b/synapsex/neural.py
@@ -1,7 +1,19 @@
 import os
+import sys
 from dataclasses import replace
 from typing import Dict, Tuple, List, Optional
 
+import matplotlib
+
+# Only fall back to a non-interactive backend when running headless on
+# platforms that honour the ``DISPLAY`` variable (i.e. Unix).  Windows users
+# typically have a display even when ``DISPLAY`` is unset, so we avoid forcing
+# the ``Agg`` backend there.
+if os.environ.get("DISPLAY", "") == "" and sys.platform != "win32":
+    matplotlib.use("Agg")
+matplotlib.rcParams["figure.max_open_warning"] = 0
+import matplotlib.pyplot as plt
+import numpy as np
 import torch
 from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
@@ -69,12 +81,12 @@ class PyTorchANN:
         patience: int = 3,
         min_epochs: int = 5,
         val_split: float = 0.2,
-    ) -> Dict[str, float]:
-        """Train the network and return evaluation metrics.
+    ) -> Tuple[Dict[str, float], List[plt.Figure]]:
+        """Train the network and return evaluation metrics and figures.
 
-        Uses a small validation split for early stopping based on the F1 score
-        and restores the best observed model weights.  ``min_epochs`` guarantees
-        that a few epochs are always run so the network can start learning."""
+        The function always generates training curves, weight heatmaps and a
+        confusion matrix for consumers such as the GUI.  Callers can decide
+        how to display or embed the returned figures."""
 
         # Split the data into a deterministic training/validation partition so
         # early stopping decisions are based on unseen samples.
@@ -92,32 +104,60 @@ class PyTorchANN:
         criterion = nn.CrossEntropyLoss()
         self.model.train()
 
+        loss_hist: List[float] = []
+        acc_hist: List[float] = []
+        prec_hist: List[float] = []
+        rec_hist: List[float] = []
+        f1_hist: List[float] = []
+
         best_f1 = -1.0
         best_state: Optional[dict] = None
         stale_epochs = 0
 
-        for epoch in range(self.hp.epochs):
+        for _ in range(self.hp.epochs):
+            epoch_loss = 0.0
+            total = 0
             for xb, yb in train_loader:
                 opt.zero_grad()
                 logits = self.model(xb)
                 loss = criterion(logits, yb)
                 loss.backward()
                 opt.step()
+                epoch_loss += float(loss.item()) * xb.size(0)
+                total += xb.size(0)
 
-            metrics = self.evaluate(val_X, val_y)
-            if metrics["f1"] > best_f1 + 1e-4:
-                best_f1 = metrics["f1"]
+            loss_hist.append(epoch_loss / total if total else 0.0)
+            train_metrics = self.evaluate(train_X, train_y)
+            acc_hist.append(train_metrics["accuracy"])
+            prec_hist.append(train_metrics["precision"])
+            rec_hist.append(train_metrics["recall"])
+            f1_hist.append(train_metrics["f1"])
+
+            val_metrics = self.evaluate(val_X, val_y)
+            if val_metrics["f1"] > best_f1 + 1e-4:
+                best_f1 = val_metrics["f1"]
                 best_state = self.model.state_dict()
                 stale_epochs = 0
             else:
                 stale_epochs += 1
-                if epoch + 1 >= min_epochs and stale_epochs >= patience:
+                if len(loss_hist) >= min_epochs and stale_epochs >= patience:
                     break
 
         if best_state is not None:
             self.model.load_state_dict(best_state)
 
-        return self.evaluate(X, y)
+        final_metrics = self.evaluate(X, y)
+
+        # Generate figures for consumers such as the GUI.
+        figs = [
+            self._plot_training(loss_hist, acc_hist, prec_hist, rec_hist, f1_hist),
+            self._plot_weights(),
+        ]
+        preds = self.predict(X).argmax(dim=1).cpu().numpy()
+        figs.append(self._plot_confusion_matrix(y.cpu().numpy(), preds))
+        figs = [fig for fig in figs if fig is not None]
+
+        return final_metrics, figs
 
     def predict(self, X: torch.Tensor, mc_dropout: bool = False) -> torch.Tensor:
         X = self._format_input(X)
@@ -229,36 +269,70 @@ class PyTorchANN:
             self.model.load_state_dict(state, strict=False)
 
 
-class RedundantNeuralIP:
-    """Manages multiple ANN instances and majority voting."""
+    # ------------------------------------------------------------------
+    # Visualisation helpers
+    # ------------------------------------------------------------------
+    def _plot_training(
+        self,
+        loss_hist: List[float],
+        acc_hist: List[float],
+        prec_hist: List[float],
+        rec_hist: List[float],
+        f1_hist: List[float],
+    ):
+        if not loss_hist:
+            return None
+        epochs = range(1, len(loss_hist) + 1)
+        fig, axes = plt.subplots(5, 1, figsize=(8, 12), sharex=True)
+        axes[0].plot(epochs, loss_hist, color="tab:red")
+        axes[0].set_ylabel("Loss")
+        axes[0].set_title("Training Progress")
+        metrics = [
+            (acc_hist, "Accuracy", "tab:blue"),
+            (prec_hist, "Precision", "tab:orange"),
+            (rec_hist, "Recall", "tab:green"),
+            (f1_hist, "F1 Score", "tab:purple"),
+        ]
+        for ax, (hist, label, color) in zip(axes[1:], metrics):
+            ax.plot(epochs, hist, color=color)
+            ax.set_ylabel(label)
+        axes[-1].set_xlabel("Epoch")
+        fig.tight_layout()
+        return fig
 
-    def __init__(self):
-        self.ann_map: Dict[int, PyTorchANN] = {}
+    def _plot_weights(self):
+        linears = [m for m in self.model.modules() if isinstance(m, nn.Linear)]
+        if not linears:
+            return None
+        cols = len(linears)
+        fig, axes = plt.subplots(1, cols, figsize=(4 * cols, 4))
+        if cols == 1:
+            axes = [axes]
+        for idx, (layer, ax) in enumerate(zip(linears, axes)):
+            with torch.no_grad():
+                weights = layer.weight.cpu().numpy()
+            ax.imshow(weights, cmap="seismic")
+            ax.set_title(f"Layer {idx + 1} Weights")
+            ax.set_xticks([])
+            ax.set_yticks([])
+        fig.tight_layout()
+        return fig
 
-    def create_ann(self, ann_id: int) -> None:
-        self.ann_map[ann_id] = PyTorchANN()
-
-    def train_ann(self, ann_id: int, X: torch.Tensor, y: torch.Tensor) -> None:
-        self.ann_map[ann_id].train(X, y)
-
-    def predict_ann(self, ann_id: int, X: torch.Tensor, mc_dropout: bool = True) -> torch.Tensor:
-        return self.ann_map[ann_id].predict(X, mc_dropout=mc_dropout)
-
-    def save_all(self, prefix: str) -> None:
-        os.makedirs(prefix, exist_ok=True)
-        for ann_id, ann in self.ann_map.items():
-            ann.save(os.path.join(prefix, f"ann_{ann_id}.pt"))
-
-    def load_all(self, prefix: str) -> None:
-        for ann_id, ann in self.ann_map.items():
-            path = os.path.join(prefix, f"ann_{ann_id}.pt")
-            if os.path.exists(path):
-                ann.load(path)
-
-    def majority_vote(self, X: torch.Tensor) -> Tuple[int, torch.Tensor]:
-        probs: List[torch.Tensor] = []
-        for ann in self.ann_map.values():
-            probs.append(ann.predict(X, mc_dropout=True))
-        mean_prob = torch.stack(probs).mean(0)
-        pred = int(mean_prob.argmax(dim=1)[0])
-        return pred, mean_prob[0]
+    def _plot_confusion_matrix(self, y_true: np.ndarray, y_pred: np.ndarray):
+        num_classes = int(max(y_true.max(), y_pred.max()) + 1)
+        cm = np.zeros((num_classes, num_classes), dtype=int)
+        for t, p in zip(y_true, y_pred):
+            cm[int(t), int(p)] += 1
+        fig, ax = plt.subplots()
+        im = ax.imshow(cm, cmap=plt.cm.Blues)
+        fig.colorbar(im, ax=ax)
+        ax.set_xlabel("Predicted")
+        ax.set_ylabel("Actual")
+        ax.set_xticks(range(num_classes))
+        ax.set_yticks(range(num_classes))
+        ax.set_title("Confusion Matrix")
+        for i in range(num_classes):
+            for j in range(num_classes):
+                ax.text(j, i, str(cm[i, j]), ha="center", va="center", color="black")
+        plt.tight_layout()
+        return fig


### PR DESCRIPTION
## Summary
- Store per-ANN training metrics and figures for later display
- Show metrics, weight heatmaps and confusion matrices in GUI tabs and print inferred class
- Suppress Matplotlib "max open figures" warnings

## Testing
- `pytest tests/test_transformer_classifier.py::test_transformer_classifier_hw_match -q` *(fails: iverilog not installed)*
- `sudo apt-get update -y` *(fails: 403  Forbidden [IP: 172.30.0.83 8080])*

------
https://chatgpt.com/codex/tasks/task_b_6893c1ad749083278ccf0a079c4bec72