### PR TITLE
feat: add dark mode toggle for ASM editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ hand-written characters.
   emulated hardware or launch neural-network operations.
 - **Graphical interface.** `python SynapseX.py gui` opens a Tk GUI to edit and
   execute assembly files, load images and inspect results.
+- **Dark mode.** Toggle the ASM editor between light and dark themes for
+  comfortable coding.
 - **Training and inference.** Neural networks can be trained on a directory of
   labelled images or used to classify a single image from the command line.
 - **Evaluation metrics.** Training curves track loss, accuracy, precision,

--- a/SynapseX.py
+++ b/SynapseX.py
@@ -97,8 +97,10 @@ class SynapseXGUI(tk.Tk):
         style = ttk.Style(self)
         style.theme_use("clam")
         self.current_asm_path: Path | None = None
+        self.dark_mode = False
         self._build_menu()
         self._build_ui()
+        self._set_dark_mode(False)
 
     def _build_menu(self) -> None:
         menubar = tk.Menu(self)
@@ -155,6 +157,11 @@ class SynapseXGUI(tk.Tk):
         run_btn = ttk.Button(right, text="Run Program", command=self.run_selected)
         run_btn.pack(fill=tk.X, padx=5)
 
+        self.dark_mode_btn = ttk.Button(
+            right, text="Dark Mode", command=self.toggle_dark_mode
+        )
+        self.dark_mode_btn.pack(fill=tk.X, padx=5, pady=5)
+
         ttk.Label(right, text="Training Data").pack(anchor="w", padx=5, pady=(10, 0))
         self.data_entry = ttk.Entry(right)
         self.data_entry.pack(fill=tk.X, padx=5)
@@ -177,6 +184,32 @@ class SynapseXGUI(tk.Tk):
         frame.rowconfigure(0, weight=1)
         frame.columnconfigure(0, weight=1)
         return frame, text
+
+    def _set_dark_mode(self, enable: bool) -> None:
+        if enable:
+            bg = "#1e1e1e"
+            fg = "#d4d4d4"
+            instr = "#569CD6"
+            number = "#B5CEA8"
+            comment = "#6A9955"
+        else:
+            bg = "white"
+            fg = "black"
+            instr = "#0066CC"
+            number = "#CC0000"
+            comment = "#008000"
+        self.asm_text.configure(background=bg, foreground=fg, insertbackground=fg)
+        self.asm_text.tag_configure("instr", foreground=instr)
+        self.asm_text.tag_configure("number", foreground=number)
+        self.asm_text.tag_configure("comment", foreground=comment)
+
+    def toggle_dark_mode(self) -> None:
+        self.dark_mode = not self.dark_mode
+        self._set_dark_mode(self.dark_mode)
+        self.dark_mode_btn.config(
+            text="Light Mode" if self.dark_mode else "Dark Mode"
+        )
+        self._highlight_asm()
 
     def choose_data_dir(self) -> None:
         path = filedialog.askdirectory(title="Select Training Data Directory")


### PR DESCRIPTION
## Summary
- add a toggle button to switch the ASM editor between light and dark themes
- document the new dark mode capability in the README

## Testing
- `python -m pytest` *(fails: RuntimeError: iverilog not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6894239e61508327a84ace45bb24c844