### PR TITLE
Default to dark mode with magenta numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ hand-written characters.
   emulated hardware or launch neural-network operations.
 - **Graphical interface.** `python SynapseX.py gui` opens a Tk GUI to edit and
   execute assembly files, load images and inspect results.
-- **Dark mode.** Toggle the ASM editor between light and dark themes for
-  comfortable coding.
+- **Dark mode.** The ASM editor now launches in dark mode with magenta numbers
+  and can toggle to a light theme for comfortable coding.
 - **Training and inference.** Neural networks can be trained on a directory of
   labelled images or used to classify a single image from the command line.
 - **Evaluation metrics.** Training curves track loss, accuracy, precision,

--- a/SynapseX.py
+++ b/SynapseX.py
@@ -97,9 +97,11 @@ class SynapseXGUI(tk.Tk):
         style = ttk.Style(self)
         style.theme_use("clam")
         self.current_asm_path: Path | None = None
-        self.dark_mode = False
+        self.dark_mode = True
         self._build_menu()
         self._build_ui()
+        self._set_dark_mode(self.dark_mode)
+        self.dark_mode_btn.config(text="Light Mode")
 
     def _build_menu(self) -> None:
         menubar = tk.Menu(self)
@@ -189,7 +191,7 @@ class SynapseXGUI(tk.Tk):
             bg = "#1e1e1e"
             fg = "#d4d4d4"
             instr = "#569CD6"
-            number = "#B5CEA8"
+            number = "#FF00FF"
             comment = "#6A9955"
         else:
             bg = "white"


### PR DESCRIPTION
## Summary
- Start GUI in dark mode by default and adjust toggle button
- Use magenta for numbers when dark mode is active
- Document dark-mode default and magenta numbers in README

## Testing
- `pytest -q` *(fails: RuntimeError: iverilog not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68942952fd4c83279e5b013d4c04e75b