### PR TITLE
Stop saving rotated images during classification

### DIFF
--- a/SynapseX.py
+++ b/SynapseX.py
@@ -265,9 +265,7 @@ class SynapseXGUI(tk.Tk):
         )
         if not path:
             return
-        processed_dir = Path.cwd() / "processed"
-        processed_imgs = load_process_shape_image(path, out_dir=processed_dir, save=True)
-        processed = processed_imgs[0]
+        processed = load_process_shape_image(path, angles=[0])[0]
         soc = SoC()
         base_addr = 0x5000
         for i, val in enumerate(processed):
@@ -471,8 +469,7 @@ def main() -> None:
             print(f"Image '{image_path}' not found.")
             return
         soc = SoC()
-        processed_dir = Path.cwd() / "processed"
-        processed = load_process_shape_image(str(image_path), out_dir=processed_dir, angles=[0])[0]
+        processed = load_process_shape_image(str(image_path), angles=[0])[0]
         base_addr = 0x5000
         for i, val in enumerate(processed):
             word = np.frombuffer(np.float32(val).tobytes(), dtype=np.uint32)[0]

--- a/synapse/models/redundant_ip.py
+++ b/synapse/models/redundant_ip.py
@@ -205,9 +205,7 @@ class RedundantNeuralIP:
                     letter = img_path.stem.split("_")[0].upper()
                     if letter not in letter2label:
                         continue
-                    processed = load_process_shape_image(
-                        str(img_path), out_dir=Path(self.train_data_dir) / "processed"
-                    )
+                    processed = load_process_shape_image(str(img_path))
                     X_list.extend(processed)
                     y_list.extend([letter2label[letter]] * len(processed))
                 if not X_list:

--- a/synapsex/image_processing.py
+++ b/synapsex/image_processing.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os
-from pathlib import Path
 import numpy as np
 from PIL import Image
 from typing import Iterable, List
@@ -126,11 +124,9 @@ def morph_dilate(binary_image: np.ndarray, kernel_size: int = 3, iterations: int
 def load_process_shape_image(
     path: str,
     target_size: int = 28,
-    save: bool = True,
     canny_low: float = 50,
     canny_high: float = 150,
     dilation_iter: int = 1,
-    out_dir: str | None = None,
     angles: Iterable[int] = range(0, 181, 10),
 ) -> List[np.ndarray]:
     try:
@@ -158,12 +154,5 @@ def load_process_shape_image(
             Image.fromarray(dilated.astype(np.uint8)).resize((target_size, target_size), resample=resample_lanczos),
             dtype=np.float32,
         ) / 255.0
-        if save:
-            base = Path(path).name
-            fname, _ = os.path.splitext(base)
-            proc_root = Path(out_dir) if out_dir else Path(path).parent / "processed_images"
-            proc_root.mkdir(parents=True, exist_ok=True)
-            save_path = proc_root / f"{fname}_rot{angle}.png"
-            Image.fromarray((norm_img * 255).astype(np.uint8)).save(save_path)
         processed_images.append(norm_img.flatten())
     return processed_images

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -28,7 +28,7 @@ def test_load_process_shape_image_angle_control(tmp_path):
     img = Image.fromarray(np.zeros((10, 10), dtype=np.uint8))
     path = tmp_path / "test.png"
     img.save(path)
-    multi = load_process_shape_image(str(path), save=False, angles=[0, 90])
-    single = load_process_shape_image(str(path), save=False, angles=[0])
+    multi = load_process_shape_image(str(path), angles=[0, 90])
+    single = load_process_shape_image(str(path), angles=[0])
     assert len(multi) == 2
     assert len(single) == 1


### PR DESCRIPTION
## Summary
- Avoid disk writes by removing file-saving code from `load_process_shape_image`
- Run classification directly from memory with a single angle, speeding up both GUI and CLI paths
- Update dataset loader and tests for new in-memory image processing flow

## Testing
- `pytest tests/test_image_processing.py -q`
- `pytest -q` *(fails: iverilog not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68942a0183d88327ab18a55cbaa14ee5