### PR TITLE
docs: explain GA and metric-based training

### DIFF
--- a/HYPERPARAMETERS.md
+++ b/HYPERPARAMETERS.md
@@ -54,3 +54,16 @@ The `HyperParameters` dataclass exposes similar knobs for runtime configuration.
 | `mc_dropout_passes` | `10` | Number of forward passes to average when using Monte Carlo dropout. |
 | `num_layers` | `2` | Number of transformer encoder layers used by the classifier. |
 | `nhead` | `4` | Attention heads per transformer layer. Adjusted to divide the embedding dimension. |
+
+## Genetic Algorithm Search
+
+The hyper-parameters above form the search space for the built-in genetic
+algorithm implemented in `synapsex/genetic.py`. The GA mutates dropout, learning
+rate, transformer depth and attention heads, evaluating each candidate on a
+validation split and keeping the configuration with the strongest F1 score.
+
+## Target Metrics
+
+Training tracks accuracy, precision, recall and F1 each epoch. Early stopping
+uses validation F1 as the target metric and restores the weights from the best
+scoring epoch.

--- a/README.md
+++ b/README.md
@@ -37,9 +37,13 @@ hand-written characters.
 - **Evaluation metrics.** Training curves track loss, accuracy, precision,
   recall and F1 while a confusion matrix visualises classification results for
   any number of classes.
- - **Validation-based early stopping.** Training monitors a held-out validation
-   split, restoring the best model weights to avoid the "stuck at one class"
-   behaviour and improve overall metrics.
+- **Validation-based early stopping.** Training monitors a held-out validation
+  split, restoring the best model weights to avoid the "stuck at one class"
+  behaviour and improve overall metrics.
+- **Genetic algorithm tuning.** A tiny GA explores learning rates, dropout and
+  transformer depth to squeeze out better accuracy, recall, precision and F1.
+- **Target-metrics training.** Optimisation halts when validation F1 stalls,
+  preserving the model state that achieved the strongest score.
 
 ## Getting Started
 
@@ -240,7 +244,9 @@ into a NumPy dataset and cached for reuse.  The network then trains with PyTorch
 using an Adam optimizer and cross‑entropy loss while dropout layers stay active
 to support later majority voting.  After every epoch SynapseX records loss,
 accuracy, precision, recall and F1 before finally plotting the curves and
-serialising the model weights.
+serialising the model weights.  Training is metric driven – a validation split
+tracks the F1 score and halts optimisation when the metric fails to improve,
+restoring the best performing weights.
 
 The high‑level flow is shown below:
 
@@ -271,9 +277,10 @@ helpers incorporate a couple of classic optimisation strategies:
   epochs, reducing the risk of overfitting.
 - **Genetic algorithms** explore different dropout, learning-rate and
   architectural choices (transformer depth and attention heads) and retain the
-  best scoring network to curb false positives and negatives.  The compact
-  implementation lives in `synapsex/genetic.py` and can be invoked via
-  `PyTorchANN.tune_hyperparameters_ga` before calling `train`.
+  best scoring network to curb false positives and negatives.  Fitness is the
+  validation F1 score, so the search favours architectures that meet the target
+  metric.  The compact implementation lives in `synapsex/genetic.py` and can be
+  invoked via `PyTorchANN.tune_hyperparameters_ga` before calling `train`.
 
 Trained checkpoints persist the selected hyper-parameters so classification code
 can recreate the exact network structure discovered by the search.


### PR DESCRIPTION
## Summary
- Document genetic algorithm tuning and F1-based early stopping in README
- Clarify hyper-parameter search space and metric-driven training in hyperparameter reference

## Testing
- `pytest -q` *(fails: iverilog not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68942a8549248327bb5bc800e2ff43e8