### PR TITLE
feat: support configurable channels and classes

### DIFF
--- a/synapsex/config.py
+++ b/synapsex/config.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass
 @dataclass
 class HyperParameters:
     image_size: int = 28
+    image_channels: int = 1
+    num_classes: int = 3
     dropout: float = 0.2
     learning_rate: float = 1e-3
     epochs: int = 10

--- a/synapsex/models.py
+++ b/synapsex/models.py
@@ -31,6 +31,7 @@ class TransformerClassifier(nn.Module):
         *,
         num_layers: int = 2,
         nhead: int = 4,
+        in_channels: int = 1,
     ):
         super().__init__()
         patch_size = max(image_size // 4, 1)
@@ -42,7 +43,7 @@ class TransformerClassifier(nn.Module):
                     nhead = candidate
                     break
         self.nhead = nhead
-        self.patch_embed = nn.Conv2d(1, embed_dim, kernel_size=patch_size, stride=patch_size)
+        self.patch_embed = nn.Conv2d(in_channels, embed_dim, kernel_size=patch_size, stride=patch_size)
         n_patches = (image_size // patch_size) ** 2
         # Positional embeddings for each patch
         self.pos_embed = nn.Parameter(torch.zeros(n_patches, embed_dim))
@@ -58,7 +59,7 @@ class TransformerClassifier(nn.Module):
         self.head = nn.Linear(n_patches * embed_dim, num_classes)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        # x: (batch, 1, H, W)
+        # x: (batch, in_channels, H, W)
         x = self.patch_embed(x)  # (batch, embed_dim, H/P, W/P)
         x = x.flatten(2).transpose(1, 2)  # (batch, n_patches, embed_dim)
         x = x + self.pos_embed  # add positional information


### PR DESCRIPTION
## Summary
- allow HyperParameters to specify image_channels and num_classes
- wire TransformerClassifier to accept configurable input channels
- pass new hyperparameters through PyTorchANN and reshape inputs accordingly

## Testing
- `pytest tests/test_transformer_classifier.py::test_transformer_classifier_hw_match -q` *(fails: iverilog not installed)*

------
https://chatgpt.com/codex/tasks/task_b_689482b006a48327b810f1cf1e0eb56e