### PR TITLE
Add vehicle dataset loader and integrate into training

### DIFF
--- a/synapse/models/redundant_ip.py
+++ b/synapse/models/redundant_ip.py
@@ -40,7 +40,7 @@ import torch
 from synapsex.config import HyperParameters, hp
 from synapsex.genetic import genetic_search
 from synapsex.neural import PyTorchANN
-from synapsex.image_processing import load_process_shape_image
+from synapsex.image_processing import load_vehicle_dataset
 
 
 class RedundantNeuralIP:
@@ -50,7 +50,7 @@ class RedundantNeuralIP:
         self.ann_map: Dict[int, PyTorchANN] = {}
         self.last_result: int | None = None
         self.train_data_dir = train_data_dir
-        self._cached_dataset: tuple[np.ndarray, np.ndarray] | None = None
+        self._cached_dataset: tuple[torch.Tensor, torch.Tensor] | None = None
         # Metrics and figures generated during training keyed by ANN ID
         self.metrics_by_ann: Dict[int, Dict[str, float]] = {}
         self.figures_by_ann: Dict[int, List] = {}
@@ -119,7 +119,7 @@ class RedundantNeuralIP:
 
         # Update only the epoch count; GA-tuned learning rate and batch size are preserved
         ann.hp = replace(ann.hp, epochs=epochs)
-        metrics, figs = ann.train(torch.from_numpy(X), torch.from_numpy(y))
+        metrics, figs = ann.train(X, y)
         for old in self.figures_by_ann.get(ann_id, []):
             plt.close(old)
         self.figures_by_ann[ann_id] = figs
@@ -166,8 +166,10 @@ class RedundantNeuralIP:
         X, y = dataset
 
         best_hp, best_ann = genetic_search(
-            torch.from_numpy(X), torch.from_numpy(y),
-            generations=generations, population_size=population,
+            X,
+            y,
+            generations=generations,
+            population_size=population,
         )
         self.ann_map[ann_id] = best_ann
 
@@ -194,30 +196,12 @@ class RedundantNeuralIP:
             data_path = Path(self.train_data_dir) / "data.npy"
             labels_path = Path(self.train_data_dir) / "labels.npy"
             if not data_path.exists() or not labels_path.exists():
-                X_list: List[np.ndarray] = []
-                y_list: List[int] = []
-                letter2label = {"A": 0, "B": 1, "C": 2}
-                image_files = (
-                    sorted(Path(self.train_data_dir).glob("*.png"))
-                    + sorted(Path(self.train_data_dir).glob("*.jpg"))
-                )
-                for img_path in image_files:
-                    letter = img_path.stem.split("_")[0].upper()
-                    if letter not in letter2label:
-                        continue
-                    processed = load_process_shape_image(str(img_path))
-                    X_list.extend(processed)
-                    y_list.extend([letter2label[letter]] * len(processed))
-                if not X_list:
-                    print("No training images found; aborting training.")
-                    return None
-                X = np.stack(X_list).astype(np.float32)
-                y = np.array(y_list, dtype=np.int64)
-                np.save(data_path, X)
-                np.save(labels_path, y)
+                X, y = load_vehicle_dataset(self.train_data_dir, hp.image_size)
+                np.save(data_path, X.numpy())
+                np.save(labels_path, y.numpy())
             else:
-                X = np.load(data_path).astype(np.float32)
-                y = np.load(labels_path).astype(np.int64)
+                X = torch.from_numpy(np.load(data_path).astype(np.float32))
+                y = torch.from_numpy(np.load(labels_path).astype(np.int64))
             self._cached_dataset = (X, y)
         return self._cached_dataset
 

--- a/synapsex/image_processing.py
+++ b/synapsex/image_processing.py
@@ -15,9 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import numpy as np
-from PIL import Image
+from pathlib import Path
 from typing import Iterable, List
+
+import numpy as np
+import torch
+from PIL import Image
 
 
 def gaussian_kernel(size: int = 5, sigma: float = 1.4) -> np.ndarray:
@@ -119,6 +122,52 @@ def morph_dilate(binary_image: np.ndarray, kernel_size: int = 3, iterations: int
                     temp[i, j] = 255
         out = temp
     return out
+
+
+def preprocess_vehicle_image(path: str, target_size: int = 28) -> torch.Tensor:
+    """Convert ``path`` to a flattened grayscale tensor of size ``target_size``."""
+    try:
+        resample = Image.Resampling.LANCZOS
+    except AttributeError:  # pragma: no cover - Pillow < 9
+        resample = Image.LANCZOS
+    img = Image.open(path).convert("L").resize((target_size, target_size), resample=resample)
+    arr = np.array(img, dtype=np.float32) / 255.0
+    return torch.from_numpy(arr.flatten())
+
+
+def load_vehicle_dataset(root_dir: str, target_size: int = 28) -> tuple[torch.Tensor, torch.Tensor]:
+    """Load vehicle images from class-named subdirectories.
+
+    Parameters
+    ----------
+    root_dir:
+        Root directory containing one subfolder per vehicle class.
+    target_size:
+        Square size to which all images are resized.
+
+    Returns
+    -------
+    X, y:
+        ``X`` is a tensor of flattened images and ``y`` contains integer class
+        labels.
+    """
+
+    root = Path(root_dir)
+    images: List[torch.Tensor] = []
+    labels: List[int] = []
+    class_names = sorted([d.name for d in root.iterdir() if d.is_dir()])
+    class_to_idx = {name: idx for idx, name in enumerate(class_names)}
+    for cls in class_names:
+        for img_path in sorted((root / cls).glob("*")):
+            if img_path.suffix.lower() not in {".png", ".jpg", ".jpeg", ".bmp"}:
+                continue
+            images.append(preprocess_vehicle_image(str(img_path), target_size))
+            labels.append(class_to_idx[cls])
+    if not images:
+        raise ValueError("No images found in dataset")
+    X = torch.stack(images)
+    y = torch.tensor(labels, dtype=torch.long)
+    return X, y
 
 
 def load_process_shape_image(

--- a/tests/test_vehicle_dataset.py
+++ b/tests/test_vehicle_dataset.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2025 Miguel Marina
+# Author: Miguel Marina <karel.capek.robotics@gmail.com>
+# LinkedIn: https://www.linkedin.com/in/progman32/
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+import sys
+
+import numpy as np
+from PIL import Image
+
+sys.path.append(os.getcwd())
+from synapsex.image_processing import load_vehicle_dataset
+
+
+def test_load_vehicle_dataset(tmp_path):
+    (tmp_path / "car").mkdir()
+    (tmp_path / "truck").mkdir()
+    Image.fromarray(np.zeros((10, 10), dtype=np.uint8)).save(tmp_path / "car" / "a.png")
+    Image.fromarray(np.full((10, 10), 255, dtype=np.uint8)).save(tmp_path / "truck" / "b.png")
+
+    X, y = load_vehicle_dataset(tmp_path, target_size=8)
+    assert X.shape == (2, 64)
+    assert y.tolist() == [0, 1]


### PR DESCRIPTION
## Summary
- add image preprocessing and dataset loader for vehicle images
- integrate vehicle dataset loader into neural IP training and tuning routines
- add unit test for vehicle dataset loader

## Testing
- `pytest -q` *(fails: iverilog not installed)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689482b09cec83278972d6166d8d16f1