### PR TITLE
Refactor classification voting to use neural IP argmax

### DIFF
--- a/asm/training.asm
+++ b/asm/training.asm
@@ -20,6 +20,10 @@ OP_NEUR CONFIG_ANN 0 FINALIZE 0.2
 OP_NEUR CONFIG_ANN 1 FINALIZE 0.2
 OP_NEUR CONFIG_ANN 2 FINALIZE 0.2
 
+; (A1) Load class count from configuration to remain in sync with Python code
+OP_NEUR GET_NUM_CLASSES
+ADD $s0, $zero, $t9            ; $s0 holds hp.num_classes
+
 ; (B) Tune hyperparameters via a genetic algorithm
 OP_NEUR TUNE_GA 0 5 8
 OP_NEUR TUNE_GA 1 5 8


### PR DESCRIPTION
## Summary
- Retrieve class count from configuration in both assembly programs
- Query each ANN's argmax via the neural IP and loop over classes to tally votes
- Replace hand-written voting logic with generic loop driven by `hp.num_classes`

## Testing
- `pytest` *(fails: iverilog not installed)*


------
https://chatgpt.com/codex/tasks/task_b_689482b14b188327a533898d016d504f