### PR TITLE
Limit dataset rotations to 36 images

### DIFF
--- a/synapsex/image_processing.py
+++ b/synapsex/image_processing.py
@@ -159,8 +159,9 @@ def load_vehicle_dataset(
     target_size:
         Square size to which all images are resized.
     rotate:
-        If ``True`` each image is augmented with 359 additional rotations
-        covering the full 360° range.
+        If ``True`` each image is augmented with rotations every 10°
+        covering the full 360° range (36 orientations including the
+        original).
 
     Returns
     -------
@@ -183,16 +184,17 @@ def load_vehicle_dataset(
             if img_path.suffix.lower() not in {".png", ".jpg", ".jpeg", ".bmp"}:
                 continue
             pil_img = Image.open(img_path).convert("L")
-            images.append(preprocess_vehicle_image(pil_img, target_size))
-            labels.append(class_to_idx[cls])
             if rotate:
                 bg_color = pil_img.getpixel((0, 0))
-                for angle in range(1, 360):
+                for angle in range(0, 360, 10):
                     rotated = pil_img.rotate(
                         angle, resample=resample_bicubic, expand=True, fillcolor=bg_color
                     )
                     images.append(preprocess_vehicle_image(rotated, target_size))
                     labels.append(class_to_idx[cls])
+            else:
+                images.append(preprocess_vehicle_image(pil_img, target_size))
+                labels.append(class_to_idx[cls])
     if not images:
         raise ValueError("No images found in dataset")
     X = torch.stack(images)

--- a/tests/test_vehicle_dataset.py
+++ b/tests/test_vehicle_dataset.py
@@ -36,8 +36,8 @@ def _prepare_dataset(tmp_path):
 def test_load_vehicle_dataset(tmp_path):
     _prepare_dataset(tmp_path)
     X, y = load_vehicle_dataset(tmp_path, target_size=8)
-    assert X.shape == (720, 64)
-    assert torch.bincount(y).tolist() == [360, 360]
+    assert X.shape == (72, 64)
+    assert torch.bincount(y).tolist() == [36, 36]
 
 
 def test_load_vehicle_dataset_no_rotate(tmp_path):


### PR DESCRIPTION
## Summary
- Reduce vehicle dataset augmentation to 10° steps, generating 36 orientations including the original image
- Update dataset loader docstring and tests for new rotation scheme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68949d4a7a348327b57a132d5cef7693