### PR TITLE
Expand vehicle dataset rotation augmentation

### DIFF
--- a/synapsex/image_processing.py
+++ b/synapsex/image_processing.py
@@ -159,8 +159,8 @@ def load_vehicle_dataset(
     target_size:
         Square size to which all images are resized.
     rotate:
-        If ``True`` each image is augmented with rotations every 10°
-        covering the full 360° range (36 orientations including the
+        If ``True`` each image is augmented with rotations every 5°
+        covering the full 360° range (72 orientations including the
         original).
 
     Returns
@@ -186,7 +186,7 @@ def load_vehicle_dataset(
             pil_img = Image.open(img_path).convert("L")
             if rotate:
                 bg_color = pil_img.getpixel((0, 0))
-                for angle in range(0, 360, 10):
+                for angle in range(0, 360, 5):
                     rotated = pil_img.rotate(
                         angle, resample=resample_bicubic, expand=True, fillcolor=bg_color
                     )

--- a/tests/test_vehicle_dataset.py
+++ b/tests/test_vehicle_dataset.py
@@ -36,8 +36,8 @@ def _prepare_dataset(tmp_path):
 def test_load_vehicle_dataset(tmp_path):
     _prepare_dataset(tmp_path)
     X, y = load_vehicle_dataset(tmp_path, target_size=8)
-    assert X.shape == (72, 64)
-    assert torch.bincount(y).tolist() == [36, 36]
+    assert X.shape == (144, 64)
+    assert torch.bincount(y).tolist() == [72, 72]
 
 
 def test_load_vehicle_dataset_no_rotate(tmp_path):


### PR DESCRIPTION
## Summary
- Rotate each vehicle image every 5 degrees, generating 72 orientations per image
- Adjust dataset test expectations for 144 total samples, equally split between classes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894a56c7e048327a67c94848b50a6a2