### PR TITLE
Expose STPA control actions and analysis tooling

### DIFF
--- a/synapsex/__init__.py
+++ b/synapsex/__init__.py
@@ -15,6 +15,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .object_detection import Detection, MultiObjectDetector, detect_objects
+try:  # optional dependency: torch
+    from .object_detection import Detection, MultiObjectDetector, detect_objects
+except Exception:  # pragma: no cover - executed only when deps missing
+    Detection = MultiObjectDetector = detect_objects = None
 
-__all__ = ["Detection", "MultiObjectDetector", "detect_objects"]
+from .stpa import ControlFlowDiagram, STPAAnalysis, STPAElement
+from .tools import create_stpa_analysis
+
+__all__ = [
+    "Detection",
+    "MultiObjectDetector",
+    "detect_objects",
+    "ControlFlowDiagram",
+    "STPAAnalysis",
+    "STPAElement",
+    "create_stpa_analysis",
+]

--- a/synapsex/stpa.py
+++ b/synapsex/stpa.py
@@ -1,0 +1,59 @@
+"""Minimal STPA support utilities.
+
+This module provides lightweight classes to model a control flow diagram
+and its associated STPA elements.  When creating a new ``STPAElement``
+instance, the available control actions are derived directly from the
+selected ``ControlFlowDiagram``.  This allows user interfaces to populate
+an action combo box with the correct options.
+
+The module also exposes a simple ``STPAAnalysis`` container which can be
+used by higher level tools.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List
+
+
+@dataclass
+class ControlFlowDiagram:
+    """Representation of a control flow diagram.
+
+    Parameters
+    ----------
+    control_actions:
+        Iterable of available control actions in the diagram.
+    """
+
+    control_actions: Iterable[str] = field(default_factory=list)
+
+    def get_control_actions(self) -> List[str]:
+        """Return control actions defined by the diagram."""
+        return list(self.control_actions)
+
+
+@dataclass
+class STPAElement:
+    """STPA element bound to a control flow diagram."""
+
+    diagram: ControlFlowDiagram
+    action: str | None = None
+
+    def available_actions(self) -> List[str]:
+        """List actions from the associated control flow diagram.
+
+        This method can be used by graphical interfaces to populate the
+        Action combo box when a new element is created.
+        """
+
+        return self.diagram.get_control_actions()
+
+
+@dataclass
+class STPAAnalysis:
+    """Container for an STPA analysis result."""
+
+    diagram: ControlFlowDiagram
+    elements: List[STPAElement] = field(default_factory=list)
+

--- a/synapsex/tools.py
+++ b/synapsex/tools.py
@@ -1,0 +1,27 @@
+"""Helper functions for SynapseX tools."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from .stpa import ControlFlowDiagram, STPAAnalysis, STPAElement
+
+
+def create_stpa_analysis(
+    control_actions: Iterable[str],
+    elements: Iterable[STPAElement] | None = None,
+) -> STPAAnalysis:
+    """Create a new :class:`STPAAnalysis` object.
+
+    Parameters
+    ----------
+    control_actions:
+        Collection of control actions that define the control flow diagram.
+    elements:
+        Optional iterable of existing :class:`STPAElement` instances to include
+        in the analysis.
+    """
+
+    diagram = ControlFlowDiagram(control_actions)
+    return STPAAnalysis(diagram, list(elements) if elements else [])
+

--- a/tests/test_stpa.py
+++ b/tests/test_stpa.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for direct module imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from synapsex.stpa import ControlFlowDiagram, STPAElement
+from synapsex.tools import create_stpa_analysis
+
+
+def test_available_actions_lists_from_diagram():
+    diagram = ControlFlowDiagram(["A", "B"])
+    element = STPAElement(diagram)
+    assert element.available_actions() == ["A", "B"]
+
+
+def test_create_stpa_analysis_builds_analysis():
+    elements = []
+    analysis = create_stpa_analysis(["A"], elements)
+    assert analysis.diagram.get_control_actions() == ["A"]
+    assert analysis.elements == elements


### PR DESCRIPTION
## Summary
- add minimal STPA model so elements pull actions from their control flow diagram
- provide `create_stpa_analysis` helper in tools module
- make STPA utilities available from package while handling missing optional deps

## Testing
- `pytest tests/test_stpa.py -q`
- `pip install torch matplotlib -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894a9a4615c8327b8cda43f04ab0ee6