### PR TITLE
Fix majority voting result mapping to class names

### DIFF
--- a/synapse/hardware/cpu.py
+++ b/synapse/hardware/cpu.py
@@ -69,8 +69,9 @@ class CPU:
             self.running = False
             if self.neural_ip.last_result is not None:
                 result = self.get_reg("$t9")
-                label_map = {0: "A", 1: "B", 2: "Unknown"}
-                print(f"Final classification: {label_map.get(result, result)}")
+                class_names = getattr(self.neural_ip, "class_names", [])
+                label = class_names[result] if 0 <= result < len(class_names) else result
+                print(f"Final classification: {label}")
         elif instr == "ADDI":
             rd = parts[1].rstrip(",")
             rs = parts[2].rstrip(",")
@@ -99,6 +100,6 @@ class CPU:
         elif instr == "OP_NEUR":
             subcmd = " ".join(parts[1:])
             self.neural_ip.run_instruction(subcmd, memory=self.memory)
-            if subcmd.upper().startswith("INFER_ANN") and self.neural_ip.last_result is not None:
+            if any(subcmd.upper().startswith(cmd) for cmd in ("INFER_ANN", "GET_ARGMAX", "GET_NUM_CLASSES")) and self.neural_ip.last_result is not None:
                 self.set_reg("$t9", int(self.neural_ip.last_result))
 

--- a/tests/test_cpu_class_labels.py
+++ b/tests/test_cpu_class_labels.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.getcwd())
+from synapse.models.redundant_ip import RedundantNeuralIP
+from synapse.hardware.cpu import CPU
+
+
+def test_get_num_classes(tmp_path):
+    (tmp_path / "class0").mkdir()
+    (tmp_path / "class1").mkdir()
+    ip = RedundantNeuralIP(train_data_dir=str(tmp_path))
+    ip.run_instruction("GET_NUM_CLASSES")
+    assert ip.last_result == 2
+
+
+def test_cpu_halt_uses_class_names(capsys):
+    ip = RedundantNeuralIP()
+    ip.class_names = ["class0", "class1"]
+    ip.last_result = 1
+    cpu = CPU("CPU1", None, ip, None, None)
+    cpu.set_reg("$t9", 1)
+    cpu.step(["HALT"])
+    captured = capsys.readouterr().out
+    assert "Final classification: class1" in captured


### PR DESCRIPTION
## Summary
- ensure neural instruction processor returns number of classes and exposes class labels
- print final classification using dataset class names and update register after new neural ops
- add tests for class name handling and class count retrieval

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894af14b15c8327817188cc6dfca611