### PR TITLE
Add vote tracking for ANN inference

### DIFF
--- a/synapse/models/redundant_ip.py
+++ b/synapse/models/redundant_ip.py
@@ -55,6 +55,8 @@ class RedundantNeuralIP:
         # Metrics and figures generated during training keyed by ANN ID
         self.metrics_by_ann: Dict[int, Dict[str, float]] = {}
         self.figures_by_ann: Dict[int, List] = {}
+        # History of predictions for majority voting or debugging
+        self.vote_history: List[int] = []
 
     # ------------------------------------------------------------------
     # Assembly interface
@@ -226,6 +228,7 @@ class RedundantNeuralIP:
             mc_dropout=len(tokens) > 1 and tokens[1].lower() == "true",
         )
         self.last_result = int(probs.argmax(dim=1)[0])
+        self.vote_history.append(self.last_result)
         print(f"ANN {ann_id} prediction: {self.last_result}")
 
     # ------------------------------------------------------------------

--- a/tests/test_vote_history.py
+++ b/tests/test_vote_history.py
@@ -1,0 +1,23 @@
+import numpy as np
+from synapse.models.redundant_ip import RedundantNeuralIP
+
+
+class DummyMemory:
+    def __init__(self, data):
+        self.data = data
+
+    def read(self, addr: int) -> int:
+        idx = addr - 0x5000
+        val = self.data[idx]
+        return np.frombuffer(np.float32(val).tobytes(), dtype=np.uint32)[0]
+
+
+def test_vote_history_records_predictions():
+    ip = RedundantNeuralIP()
+    ip.run_instruction("CONFIG_ANN 0 FINALIZE")
+    ann = ip.ann_map[0]
+    # Provide a zeroed input image
+    data = np.zeros(ann.hp.image_size * ann.hp.image_size, dtype=np.float32)
+    memory = DummyMemory(data)
+    ip.run_instruction("INFER_ANN 0", memory=memory)
+    assert ip.vote_history == [ip.last_result]


### PR DESCRIPTION
## Summary
- track inference results inside `RedundantNeuralIP` for majority vote or debugging
- record each result during inference and expose via `vote_history`
- add test ensuring vote history collects predictions

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894b83bc2f08327b4e115819e865efa