### PR TITLE
Implement dynamic class handling and majority voting

### DIFF
--- a/SynapseX.py
+++ b/SynapseX.py
@@ -351,13 +351,15 @@ class SynapseXGUI(tk.Tk):
             soc.run(max_steps=3000)
         out = buf.getvalue()
         result = soc.cpu.get_reg("$t9")
+        names = soc.neural_ip.class_names
+        label = names[result] if names and 0 <= result < len(names) else result
         if "Classification" not in self.network_tabs:
             sub_nb = ScrollableNotebook(self.results_nb)
             self.results_nb.add(sub_nb, text="Classification")
             self.network_tabs["Classification"] = sub_nb
         sub_nb = self.network_tabs["Classification"]
         frame, text = self._create_scrolled_text(sub_nb)
-        text.insert(tk.END, out + f"\nPredicted class: {result}\n")
+        text.insert(tk.END, out + f"\nPredicted class: {label}\n")
         text.config(state="disabled")
         sub_nb.add(frame, text=f"Run {len(sub_nb.tabs())+1}")
 
@@ -478,7 +480,10 @@ class SynapseXGUI(tk.Tk):
             buf.write(f"\nTk error: {exc}\n")
         out = buf.getvalue()
         if soc.neural_ip.last_result is not None:
-            out += f"\nPredicted class: {soc.neural_ip.last_result}\n"
+            idx = soc.neural_ip.last_result
+            names = soc.neural_ip.class_names
+            label = names[idx] if names and 0 <= idx < len(names) else idx
+            out += f"\nPredicted class: {label}\n"
         net_name = asm_path.stem
         if net_name not in self.network_tabs:
             sub_nb = ScrollableNotebook(self.results_nb)
@@ -538,7 +543,9 @@ def main() -> None:
         soc.load_assembly(asm_lines)
         soc.run(max_steps=3000)
         result = soc.cpu.get_reg("$t9")
-        print(f"\nClassification Phase Completed!\nPredicted class: {result}")
+        names = soc.neural_ip.class_names
+        label = names[result] if names and 0 <= result < len(names) else result
+        print(f"\nClassification Phase Completed!\nPredicted class: {label}")
     elif mode == "track":
         if len(sys.argv) < 3:
             print("Usage: python SynapseX.py track path/to/detections.txt")

--- a/synapse/hardware/cpu.py
+++ b/synapse/hardware/cpu.py
@@ -69,8 +69,12 @@ class CPU:
             self.running = False
             if self.neural_ip.last_result is not None:
                 result = self.get_reg("$t9")
-                label_map = {0: "A", 1: "B", 2: "Unknown"}
-                print(f"Final classification: {label_map.get(result, result)}")
+                names = self.neural_ip.class_names
+                if names and 0 <= result < len(names):
+                    label = names[result]
+                else:
+                    label = result
+                print(f"Final classification: {label}")
         elif instr == "ADDI":
             rd = parts[1].rstrip(",")
             rs = parts[2].rstrip(",")

--- a/tests/test_majority_voting.py
+++ b/tests/test_majority_voting.py
@@ -43,3 +43,11 @@ def test_predict_majority_picks_mode_class():
     assert majority == 1
     assert preds[0][0] == 0
     assert preds[1][0] == 1
+
+
+def test_predict_majority_requires_two_votes():
+    ip = RedundantNeuralIP()
+    ip.ann_map = {0: DummyANN(0), 1: DummyANN(1), 2: DummyANN(2)}
+    X = np.zeros((1, 1), dtype=np.float32)
+    majority, _ = ip.predict_majority(X)
+    assert majority is None


### PR DESCRIPTION
## Summary
- Map training folder names to class indices and expose them through `RedundantNeuralIP`
- Apply 2-out-of-3 majority vote across ANNs and surface class labels in outputs
- Update CLI/GUI to display predicted class names and add tests for voting rule

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894c73cd9a483258f2e703a718cf44a