### PR TITLE
Materialize control action iterables for STPA diagrams

### DIFF
--- a/synapsex/stpa.py
+++ b/synapsex/stpa.py
@@ -28,6 +28,19 @@ class ControlFlowDiagram:
 
     control_actions: Iterable[str] = field(default_factory=list)
 
+    def __post_init__(self) -> None:
+        """Materialise ``control_actions`` into a list.
+
+        ``control_actions`` may be provided as any iterable, including
+        generators.  Generators are exhausted after a single iteration which
+        would previously result in subsequent calls to
+        :meth:`get_control_actions` returning an empty list.  By eagerly
+        converting the iterable to a list we ensure that the available control
+        actions remain accessible for the lifetime of the diagram.
+        """
+
+        self.control_actions = list(self.control_actions)
+
     def get_control_actions(self) -> List[str]:
         """Return control actions defined by the diagram."""
         return list(self.control_actions)

--- a/tests/test_stpa.py
+++ b/tests/test_stpa.py
@@ -14,6 +14,20 @@ def test_available_actions_lists_from_diagram():
     assert element.available_actions() == ["A", "B"]
 
 
+def test_diagram_materialises_iterables():
+    """Generators should remain accessible after initial iteration."""
+
+    def gen():
+        for item in ["A", "B"]:
+            yield item
+
+    diagram = ControlFlowDiagram(gen())
+    # First call consumes the generator in the constructor, so repeated
+    # calls should still yield all actions.
+    assert diagram.get_control_actions() == ["A", "B"]
+    assert diagram.get_control_actions() == ["A", "B"]
+
+
 def test_create_stpa_analysis_builds_analysis():
     elements = []
     analysis = create_stpa_analysis(["A"], elements)


### PR DESCRIPTION
## Summary
- Preserve control actions when building `ControlFlowDiagram` so STPA elements can always list available actions
- Add regression test ensuring diagram iterables are materialized

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894cf78b8008325adec798172031635