### PR TITLE
Fix assembly majority voting by supporting memory and signed branches

### DIFF
--- a/synapse/hardware/cpu.py
+++ b/synapse/hardware/cpu.py
@@ -39,10 +39,34 @@ class CPU:
         self.regs["$t9"] = 0
         self.regs["$at"] = 0
         self.label_map = {}
+        # Addresses of data labels in bytes
+        self.data_map = {}
 
     # ------------------------------------------------------------------
     def set_label_map(self, label_map):
         self.label_map = label_map
+
+    def set_data_map(self, data_map):
+        """Provide mapping from data labels to memory addresses."""
+        self.data_map = data_map
+
+    def _resolve_data_addr(self, token: str) -> int:
+        """Translate an assembly memory operand into a byte address."""
+        if "(" in token:
+            label, reg_part = token.split("(")
+            reg = reg_part.rstrip(")")
+            base = self.data_map.get(label, 0)
+            offset = self.get_reg(reg)
+            return base + offset
+        if "+" in token:
+            label, imm = token.split("+")
+            base = self.data_map.get(label, 0)
+            return base + int(imm, 0)
+        return self.data_map.get(token, 0)
+
+    def _to_signed(self, val: int) -> int:
+        """Interpret a 32-bit register value as signed."""
+        return val if val < 0x80000000 else val - 0x100000000
 
     def get_reg(self, r):
         return self.regs.get(r, 0)
@@ -85,6 +109,11 @@ class CPU:
             rs = parts[2].rstrip(",")
             rt = parts[3]
             self.set_reg(rd, self.get_reg(rs) + self.get_reg(rt))
+        elif instr == "SLL":
+            rd = parts[1].rstrip(",")
+            rt = parts[2].rstrip(",")
+            shamt = int(parts[3], 0)
+            self.set_reg(rd, self.get_reg(rt) << shamt)
         elif instr == "BEQ":
             rs = parts[1].rstrip(",")
             rt = parts[2].rstrip(",")
@@ -95,14 +124,24 @@ class CPU:
             rs = parts[1].rstrip(",")
             rt = parts[2].rstrip(",")
             label = parts[3]
-            if self.get_reg(rs) > self.get_reg(rt):
+            if self._to_signed(self.get_reg(rs)) > self._to_signed(self.get_reg(rt)):
                 self.pc = self.label_map.get(label, self.pc)
         elif instr == "J":
             label = parts[1]
             self.pc = self.label_map.get(label, self.pc)
+        elif instr == "LW":
+            rd = parts[1].rstrip(",")
+            addr_token = parts[2]
+            addr = self._resolve_data_addr(addr_token)
+            self.set_reg(rd, self.memory.read(addr // 4))
+        elif instr == "SW":
+            rs = parts[1].rstrip(",")
+            addr_token = parts[2]
+            addr = self._resolve_data_addr(addr_token)
+            self.memory.write(addr // 4, self.get_reg(rs))
         elif instr == "OP_NEUR":
             subcmd = " ".join(parts[1:])
             self.neural_ip.run_instruction(subcmd, memory=self.memory)
-            if subcmd.upper().startswith("INFER_ANN") and self.neural_ip.last_result is not None:
+            if self.neural_ip.last_result is not None:
                 self.set_reg("$t9", int(self.neural_ip.last_result))
 

--- a/synapse/soc.py
+++ b/synapse/soc.py
@@ -34,6 +34,7 @@ class SoC:
         self.cpu = CPU("CPU1", self.video_ip, self.neural_ip, self.memory, self.mmu)
         self.asm_program = []
         self.label_map = {}
+        self.data_map = {}
 
     # ------------------------------------------------------------------
     def load_assembly(self, lines):
@@ -43,11 +44,25 @@ class SoC:
 
     def _preprocess_labels(self):
         self.label_map = {}
+        self.data_map = {}
+        data_mode = False
+        data_addr = 0
         for idx, line in enumerate(self.asm_program):
             stripped = line.strip()
+            if stripped == ".data":
+                data_mode = True
+                continue
             if stripped.endswith(":"):
-                self.label_map[stripped[:-1]] = idx
+                label = stripped[:-1]
+                self.label_map[label] = idx
+                if data_mode and idx + 1 < len(self.asm_program):
+                    next_line = self.asm_program[idx + 1].strip()
+                    if next_line.startswith(".space"):
+                        size = int(next_line.split()[1])
+                        self.data_map[label] = data_addr
+                        data_addr += size
         self.cpu.set_label_map(self.label_map)
+        self.cpu.set_data_map(self.data_map)
 
     # ------------------------------------------------------------------
     def run(self, max_steps=100):

--- a/tests/test_classification_asm.py
+++ b/tests/test_classification_asm.py
@@ -1,0 +1,45 @@
+import os
+import pathlib
+import sys
+
+sys.path.append(os.getcwd())
+
+from synapse.soc import SoC
+
+
+class DummyNeuralIP:
+    """Minimal neural IP stub returning preset predictions."""
+
+    def __init__(self):
+        # predictions for three ANNs
+        self.preds = {0: 0, 1: 1, 2: 1}
+        self.last_result = None
+        self.class_names = []
+
+    def run_instruction(self, subcmd: str, memory=None) -> None:
+        tokens = subcmd.strip().split()
+        op = tokens[0].upper()
+        if op == "GET_NUM_CLASSES":
+            self.last_result = 3
+        elif op == "GET_ARGMAX":
+            ann_id = int(tokens[1])
+            self.last_result = self.preds[ann_id]
+        elif op == "INFER_ANN":
+            self.last_result = None
+        else:
+            self.last_result = None
+
+
+def test_classification_asm_majority(tmp_path):
+    # Load assembly program
+    asm_path = pathlib.Path("asm/classification.asm")
+    lines = asm_path.read_text().splitlines()
+
+    soc = SoC()
+    soc.neural_ip = DummyNeuralIP()
+    soc.cpu.neural_ip = soc.neural_ip
+    soc.load_assembly(lines)
+
+    soc.run(max_steps=500)
+
+    assert soc.cpu.get_reg("$t9") == 1


### PR DESCRIPTION
## Summary
- implement LW, SW and SLL instructions plus signed BGT in CPU
- map data labels in SoC for memory access
- test assembly majority voting end-to-end

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6894e0306f3083258fef09a0f117fdf0