### PR TITLE
Add argmax cache and expose new neural IP instructions

### DIFF
--- a/tests/test_classification_asm.py
+++ b/tests/test_classification_asm.py
@@ -1,33 +1,47 @@
 import os
 import pathlib
 import sys
+from types import SimpleNamespace
+
+import torch
 
 sys.path.append(os.getcwd())
 
 from synapse.soc import SoC
+from synapse.models.redundant_ip import RedundantNeuralIP
+from synapsex.config import hp
 
 
-class DummyNeuralIP:
-    """Minimal neural IP stub returning preset predictions."""
+class MinimalNeuralIP(RedundantNeuralIP):
+    class DummyANN:
+        def __init__(self, pred, num_classes: int = 3):
+            self.pred = pred
+            self.hp = SimpleNamespace(image_size=1, num_classes=num_classes)
+
+        def predict(self, X, mc_dropout: bool = False):
+            probs = torch.zeros((1, self.hp.num_classes))
+            probs[0, self.pred] = 1.0
+            return probs
+
+        def save(self, path):
+            pass
+
+        def load(self, path):
+            pass
 
     def __init__(self):
-        # predictions for three ANNs
-        self.preds = {0: 0, 1: 1, 2: 1}
-        self.last_result = None
-        self.class_names = []
+        super().__init__()
+        hp.num_classes = 3
+        self.class_names = ["a", "b", "c"]
+        self.stub_preds = {0: 0, 1: 1, 2: 1}
 
-    def run_instruction(self, subcmd: str, memory=None) -> None:
-        tokens = subcmd.strip().split()
-        op = tokens[0].upper()
-        if op == "GET_NUM_CLASSES":
-            self.last_result = 3
-        elif op == "GET_ARGMAX":
-            ann_id = int(tokens[1])
-            self.last_result = self.preds[ann_id]
-        elif op == "INFER_ANN":
-            self.last_result = None
-        else:
-            self.last_result = None
+    def _config_ann(self, tokens):
+        if len(tokens) < 2:
+            return
+        ann_id = int(tokens[0])
+        if tokens[1] == "FINALIZE":
+            pred = self.stub_preds[ann_id]
+            self.ann_map[ann_id] = self.DummyANN(pred)
 
 
 def test_classification_asm_majority(tmp_path):
@@ -36,10 +50,21 @@ def test_classification_asm_majority(tmp_path):
     lines = asm_path.read_text().splitlines()
 
     soc = SoC()
-    soc.neural_ip = DummyNeuralIP()
+    soc.neural_ip = MinimalNeuralIP()
     soc.cpu.neural_ip = soc.neural_ip
     soc.load_assembly(lines)
 
     soc.run(max_steps=500)
 
+    # GET_NUM_CLASSES result stored in $s0
+    assert soc.cpu.get_reg("$s0") == 3
+
+    # INFER_ANN + GET_ARGMAX cache predictions
+    assert soc.neural_ip._argmax == {0: 0, 1: 1, 2: 1}
+    base = soc.data_map["ann_preds"] // 4
+    preds = [soc.memory.read(base + i) for i in range(3)]
+    assert preds == [0, 1, 1]
+
+    # Final majority vote computed in assembly
     assert soc.cpu.get_reg("$t9") == 1
+

--- a/tests/test_vote_history.py
+++ b/tests/test_vote_history.py
@@ -1,4 +1,9 @@
+import os
+import sys
 import numpy as np
+
+sys.path.append(os.getcwd())
+
 from synapse.models.redundant_ip import RedundantNeuralIP
 
 
@@ -20,4 +25,5 @@ def test_vote_history_records_predictions():
     data = np.zeros(ann.hp.image_size * ann.hp.image_size, dtype=np.float32)
     memory = DummyMemory(data)
     ip.run_instruction("INFER_ANN 0", memory=memory)
-    assert ip.vote_history == [ip.last_result]
+    assert ip.vote_history == [ip._argmax[0]]
+    assert ip.last_result is None


### PR DESCRIPTION
## Summary
- Cache per-ANN argmax values and expose them via new `GET_ARGMAX` instruction
- Allow assembly to query `hp.num_classes` using `GET_NUM_CLASSES`
- Streamline `_infer_ann` to run per-network inference without internal voting and add a cached majority helper
- Replace dummy neural IP in classification assembly test with a lightweight `RedundantNeuralIP` subclass
- Update vote history test for new inference semantics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68950cc3b63483259f30d7b39c9a41fb