### PR TITLE
Store last inference result and gate prediction display

### DIFF
--- a/SynapseX.py
+++ b/SynapseX.py
@@ -416,8 +416,9 @@ class SynapseXGUI(tk.Tk):
         except tk.TclError as exc:
             buf.write(f"\nTk error: {exc}\n")
         out = buf.getvalue()
-        result = soc.cpu.get_reg("$t9")
-        out += f"\nPredicted class: {result}\n"
+        if soc.neural_ip.last_result is not None:
+            result = soc.cpu.get_reg("$t9")
+            out += f"\nPredicted class: {result}\n"
         net_name = asm_path.stem
         if net_name not in self.network_tabs:
             sub_nb = ScrollableNotebook(self.results_nb)

--- a/synapse/models/redundant_ip.py
+++ b/synapse/models/redundant_ip.py
@@ -96,7 +96,10 @@ class RedundantNeuralIP:
             json_path = tokens[1] if len(tokens) > 1 else "project.json"
             prefix = tokens[2] if len(tokens) > 2 else "weights"
             self.save_project(json_path, prefix)
-        self.last_result = None
+        if result is not None:
+            self.last_result = result
+        else:
+            self.last_result = None
         return result
 
     # ------------------------------------------------------------------

--- a/synapse/soc.py
+++ b/synapse/soc.py
@@ -32,6 +32,8 @@ class SoC:
         self.video_ip = VideoProcIP()
         self.neural_ip = RedundantNeuralIP(train_data_dir=train_data_dir)
         self.cpu = CPU("CPU1", self.video_ip, self.neural_ip, self.memory, self.mmu)
+        # Ensure result register starts clean to avoid stale predictions
+        self.cpu.set_reg("$t9", 0)
         self.asm_program = []
         self.label_map = {}
         self.data_map = {}

--- a/tests/test_vote_history.py
+++ b/tests/test_vote_history.py
@@ -26,4 +26,4 @@ def test_vote_history_records_predictions():
     memory = DummyMemory(data)
     ip.run_instruction("INFER_ANN 0", memory=memory)
     assert ip.vote_history == [ip._argmax[0]]
-    assert ip.last_result is None
+    assert ip.last_result == ip._argmax[0]


### PR DESCRIPTION
## Summary
- Preserve and expose last neural inference result instead of clearing it unconditionally
- Only show predicted class in the GUI when an inference actually occurred
- Reset `$t9` register on SoC startup to avoid stale predictions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68951fc581608325a76c7656233f20a1