### PR TITLE
Label confusion matrix quadrants

### DIFF
--- a/synapse/models/virtual_ann.py
+++ b/synapse/models/virtual_ann.py
@@ -206,9 +206,22 @@ class VirtualANN(nn.Module):
         ax.set_xticks(range(num_classes))
         ax.set_yticks(range(num_classes))
         ax.set_title("Confusion Matrix")
-        for i in range(num_classes):
-            for j in range(num_classes):
-                ax.text(j, i, str(cm[i, j]), ha="center", va="center", color="black")
+        if num_classes == 2:
+            labels = np.array([["TN", "FP"], ["FN", "TP"]])
+            for i in range(num_classes):
+                for j in range(num_classes):
+                    ax.text(
+                        j,
+                        i,
+                        f"{labels[i, j]}: {cm[i, j]}",
+                        ha="center",
+                        va="center",
+                        color="black",
+                    )
+        else:
+            for i in range(num_classes):
+                for j in range(num_classes):
+                    ax.text(j, i, str(cm[i, j]), ha="center", va="center", color="black")
         plt.tight_layout()
         return fig
 

--- a/synapsex/neural.py
+++ b/synapsex/neural.py
@@ -475,9 +475,22 @@ class PyTorchANN:
         ax.set_xticks(range(num_classes))
         ax.set_yticks(range(num_classes))
         ax.set_title("Confusion Matrix")
-        for i in range(num_classes):
-            for j in range(num_classes):
-                ax.text(j, i, str(cm[i, j]), ha="center", va="center", color="black")
+        if num_classes == 2:
+            labels = np.array([["TN", "FP"], ["FN", "TP"]])
+            for i in range(num_classes):
+                for j in range(num_classes):
+                    ax.text(
+                        j,
+                        i,
+                        f"{labels[i, j]}: {cm[i, j]}",
+                        ha="center",
+                        va="center",
+                        color="black",
+                    )
+        else:
+            for i in range(num_classes):
+                for j in range(num_classes):
+                    ax.text(j, i, str(cm[i, j]), ha="center", va="center", color="black")
         plt.tight_layout()
         return fig
 


### PR DESCRIPTION
## Summary
- Annotate confusion matrix plots with explicit TN/FP/FN/TP labels for binary classification.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689526d14ab88325a33199db7b3ae9de