### PR TITLE
Preserve and display classification labels

### DIFF
--- a/SynapseX.py
+++ b/SynapseX.py
@@ -314,13 +314,15 @@ class SynapseXGUI(tk.Tk):
             soc.run(max_steps=3000)
         out = buf.getvalue()
         result = soc.cpu.get_reg("$t9")
+        names = soc.neural_ip.class_names
+        label = names[result] if names and 0 <= result < len(names) else result
         if "Classification" not in self.network_tabs:
             sub_nb = ScrollableNotebook(self.results_nb)
             self.results_nb.add(sub_nb, text="Classification")
             self.network_tabs["Classification"] = sub_nb
         sub_nb = self.network_tabs["Classification"]
         frame, text = self._create_scrolled_text(sub_nb)
-        text.insert(tk.END, out + f"\nPredicted class: {result}\n")
+        text.insert(tk.END, out + f"\nPredicted class: {label}\n")
         text.config(state="disabled")
         sub_nb.add(frame, text=f"Run {len(sub_nb.tabs())+1}")
 
@@ -509,7 +511,9 @@ def main() -> None:
         soc.load_assembly(asm_lines)
         soc.run(max_steps=3000)
         result = soc.cpu.get_reg("$t9")
-        print(f"\nClassification Phase Completed!\nPredicted class: {result}")
+        names = soc.neural_ip.class_names
+        label = names[result] if names and 0 <= result < len(names) else result
+        print(f"\nClassification Phase Completed!\nPredicted class: {label}")
     elif mode == "track":
         if len(sys.argv) < 3:
             print("Usage: python SynapseX.py track path/to/detections.txt")

--- a/synapse/hardware/cpu.py
+++ b/synapse/hardware/cpu.py
@@ -73,8 +73,12 @@ class CPU:
             self.running = False
             if self.neural_ip.last_result is not None:
                 result = self.get_reg("$t9")
-                label_map = {0: "A", 1: "B", 2: "Unknown"}
-                print(f"Final classification: {label_map.get(result, result)}")
+                names = getattr(self.neural_ip, "class_names", [])
+                if names and 0 <= result < len(names):
+                    print(f"Final classification: {names[result]}")
+                else:
+                    label_map = {0: "A", 1: "B", 2: "Unknown"}
+                    print(f"Final classification: {label_map.get(result, result)}")
         elif instr == "ADDI":
             rd = parts[1].rstrip(",")
             rs = parts[2].rstrip(",")

--- a/synapsex/image_processing.py
+++ b/synapsex/image_processing.py
@@ -149,7 +149,7 @@ def preprocess_vehicle_image(
 
 def load_vehicle_dataset(
     root_dir: str, target_size: int = 28, rotate: bool = True
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, List[str]]:
     """Load vehicle images from class-named subdirectories.
 
     Parameters
@@ -165,9 +165,9 @@ def load_vehicle_dataset(
 
     Returns
     -------
-    X, y:
+    X, y, class_names:
         ``X`` is a tensor of flattened images and ``y`` contains integer class
-        labels.
+        labels. ``class_names`` lists the class directory names in index order.
     """
 
     root = Path(root_dir)
@@ -199,7 +199,7 @@ def load_vehicle_dataset(
         raise ValueError("No images found in dataset")
     X = torch.stack(images)
     y = torch.tensor(labels, dtype=torch.long)
-    return X, y
+    return X, y, class_names
 
 
 def load_process_shape_image(

--- a/tests/test_classification_asm.py
+++ b/tests/test_classification_asm.py
@@ -10,6 +10,8 @@ sys.path.append(os.getcwd())
 from synapse.soc import SoC
 from synapse.models.redundant_ip import RedundantNeuralIP
 from synapsex.config import hp
+import io
+from contextlib import redirect_stdout
 
 
 class MinimalNeuralIP(RedundantNeuralIP):
@@ -54,7 +56,10 @@ def test_classification_asm_majority(tmp_path):
     soc.cpu.neural_ip = soc.neural_ip
     soc.load_assembly(lines)
 
-    soc.run(max_steps=500)
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        soc.run(max_steps=500)
+    out = buf.getvalue()
 
     # GET_NUM_CLASSES result stored in $s0
     assert soc.cpu.get_reg("$s0") == 3
@@ -67,4 +72,5 @@ def test_classification_asm_majority(tmp_path):
 
     # Final majority vote computed in assembly
     assert soc.cpu.get_reg("$t9") == 1
+    assert "Final classification: b" in out
 

--- a/tests/test_num_classes.py
+++ b/tests/test_num_classes.py
@@ -45,7 +45,7 @@ def test_num_classes_updates_and_predictions_in_range(tmp_path):
         ip.run_instruction("CONFIG_ANN 0 FINALIZE")
         ip.run_instruction("TRAIN_ANN 0 1")
         assert hp.num_classes == 2
-        X, _ = ip._load_dataset()
+        X, _, _ = ip._load_dataset()
         probs = ip.ann_map[0].predict(X)
         assert probs.shape[1] == 2
         assert int(probs.argmax(dim=1).max().item()) <= 1

--- a/tests/test_save_project.py
+++ b/tests/test_save_project.py
@@ -12,6 +12,7 @@ def test_save_project(tmp_path):
     ip.metrics_by_ann[0] = {"accuracy": 0.5}
     fig = plt.figure()
     ip.figures_by_ann[0] = [fig]
+    ip.class_names = ["car", "truck"]
     json_path = tmp_path / "project.json"
     ip.save_project(str(json_path), "test_weights")
     data = json.loads(json_path.read_text())
@@ -22,3 +23,9 @@ def test_save_project(tmp_path):
     fig_file = tmp_path / ann_data["figures"][0]
     assert fig_file.exists()
     assert ann_data["metrics"]["accuracy"] == 0.5
+    assert data["class_names"] == ["car", "truck"]
+
+    ip2 = RedundantNeuralIP()
+    ip2.ann_map[0] = PyTorchANN()
+    ip2.load_all(str(json_path), "test_weights")
+    assert ip2.class_names == ["car", "truck"]

--- a/tests/test_vehicle_dataset.py
+++ b/tests/test_vehicle_dataset.py
@@ -35,13 +35,15 @@ def _prepare_dataset(tmp_path):
 
 def test_load_vehicle_dataset(tmp_path):
     _prepare_dataset(tmp_path)
-    X, y = load_vehicle_dataset(tmp_path, target_size=8)
+    X, y, classes = load_vehicle_dataset(tmp_path, target_size=8)
     assert X.shape == (144, 64)
     assert torch.bincount(y).tolist() == [72, 72]
+    assert classes == ["car", "truck"]
 
 
 def test_load_vehicle_dataset_no_rotate(tmp_path):
     _prepare_dataset(tmp_path)
-    X, y = load_vehicle_dataset(tmp_path, target_size=8, rotate=False)
+    X, y, classes = load_vehicle_dataset(tmp_path, target_size=8, rotate=False)
     assert X.shape == (2, 64)
     assert y.tolist() == [0, 1]
+    assert classes == ["car", "truck"]


### PR DESCRIPTION
## Summary
- expose class names from `load_vehicle_dataset`
- retain dataset class labels within `RedundantNeuralIP` and persist them via project save/load helpers
- show resolved class names in CPU halt messages and SynapseX CLI/GUI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689528cffcf88325b446826b574570a6