### PR TITLE
Use shared byte-address constant for image buffer

### DIFF
--- a/SynapseX.py
+++ b/SynapseX.py
@@ -46,6 +46,7 @@ from synapsex.image_processing import load_process_shape_image
 
 from synapse.soc import SoC
 from synapse.tracking import Detection, SortTracker
+from synapse.constants import IMAGE_BUFFER_BASE_ADDR_BYTES
 
 
 class ScrollableNotebook(ttk.Frame):
@@ -303,10 +304,10 @@ class SynapseXGUI(tk.Tk):
             return
         processed = load_process_shape_image(path, angles=[0])[0]
         soc = SoC()
-        base_addr = 0x5000
+        base_addr_bytes = IMAGE_BUFFER_BASE_ADDR_BYTES
         for i, val in enumerate(processed):
             word = np.frombuffer(np.float32(val).tobytes(), dtype=np.uint32)[0]
-            soc.memory.write(base_addr + i, int(word))
+            soc.memory.write(base_addr_bytes // 4 + i, int(word))
         asm_lines = load_asm_file(Path("asm") / "classification.asm")
         soc.load_assembly(asm_lines)
         buf = io.StringIO()
@@ -501,10 +502,10 @@ def main() -> None:
             return
         soc = SoC()
         processed = load_process_shape_image(str(image_path), angles=[0])[0]
-        base_addr = 0x5000
+        base_addr_bytes = IMAGE_BUFFER_BASE_ADDR_BYTES
         for i, val in enumerate(processed):
             word = np.frombuffer(np.float32(val).tobytes(), dtype=np.uint32)[0]
-            soc.memory.write(base_addr + i, int(word))
+            soc.memory.write(base_addr_bytes // 4 + i, int(word))
         asm_lines = load_asm_file(Path("asm") / "classification.asm")
         soc.load_assembly(asm_lines)
         soc.run(max_steps=3000)

--- a/synapse/constants.py
+++ b/synapse/constants.py
@@ -1,0 +1,8 @@
+"""Shared constants for the SynapseX project."""
+
+# Base address of the image buffer in bytes.
+# Historically this was specified in words (0x5000). Store it once here in
+# bytes to make conversions explicit.
+IMAGE_BUFFER_BASE_ADDR_BYTES = 0x5000 * 4
+
+__all__ = ["IMAGE_BUFFER_BASE_ADDR_BYTES"]

--- a/synapse/models/redundant_ip.py
+++ b/synapse/models/redundant_ip.py
@@ -41,6 +41,7 @@ from synapsex.config import HyperParameters, hp
 from synapsex.genetic import genetic_search
 from synapsex.neural import PyTorchANN
 from synapsex.image_processing import load_vehicle_dataset
+from synapse.constants import IMAGE_BUFFER_BASE_ADDR_BYTES
 
 
 class RedundantNeuralIP:
@@ -190,7 +191,8 @@ class RedundantNeuralIP:
         ann = self.ann_map.get(ann_id)
         if ann is None:
             return
-        addr = 0x5000
+        addr_bytes = IMAGE_BUFFER_BASE_ADDR_BYTES
+        addr = addr_bytes // 4
         in_dim = ann.hp.image_size * ann.hp.image_size
         data: List[float] = []
         for i in range(in_dim):

--- a/tests/test_image_buffer.py
+++ b/tests/test_image_buffer.py
@@ -1,0 +1,37 @@
+import os
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+sys.path.append(os.getcwd())
+
+from synapse.constants import IMAGE_BUFFER_BASE_ADDR_BYTES
+from synapse.models.redundant_ip import RedundantNeuralIP
+from synapse.hardware.memory import WishboneMemory
+
+
+def test_ann_receives_written_image_data():
+    ip = RedundantNeuralIP()
+    img_size = 2
+    pattern = np.arange(img_size * img_size, dtype=np.float32)
+
+    class MockANN:
+        def __init__(self, size):
+            self.hp = SimpleNamespace(image_size=size)
+            self.last_tensor = None
+
+        def predict(self, tensor, mc_dropout=False):
+            self.last_tensor = tensor
+            return torch.zeros((1, 1))
+
+    ip.ann_map[0] = MockANN(img_size)
+    memory = WishboneMemory()
+    base_words = IMAGE_BUFFER_BASE_ADDR_BYTES // 4
+    for i, val in enumerate(pattern):
+        word = np.frombuffer(np.float32(val).tobytes(), dtype=np.uint32)[0]
+        memory.write(base_words + i, int(word))
+
+    ip.run_instruction("INFER_ANN 0", memory=memory)
+    assert np.allclose(ip.ann_map[0].last_tensor.numpy().flatten(), pattern)

--- a/tests/test_vote_history.py
+++ b/tests/test_vote_history.py
@@ -4,6 +4,7 @@ import numpy as np
 
 sys.path.append(os.getcwd())
 
+from synapse.constants import IMAGE_BUFFER_BASE_ADDR_BYTES
 from synapse.models.redundant_ip import RedundantNeuralIP
 
 
@@ -12,7 +13,7 @@ class DummyMemory:
         self.data = data
 
     def read(self, addr: int) -> int:
-        idx = addr - 0x5000
+        idx = addr - IMAGE_BUFFER_BASE_ADDR_BYTES // 4
         val = self.data[idx]
         return np.frombuffer(np.float32(val).tobytes(), dtype=np.uint32)[0]
 


### PR DESCRIPTION
## Summary
- centralize image buffer base address in bytes
- convert byte addresses to word indices for ANN inference
- write classification data using byte addresses and add regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68952910dbd88325bac51d3761bd7c73