### PR TITLE
Use neural IP class names for HALT classification

### DIFF
--- a/synapse/hardware/cpu.py
+++ b/synapse/hardware/cpu.py
@@ -73,7 +73,8 @@ class CPU:
             self.running = False
             if self.neural_ip.last_result is not None:
                 result = self.get_reg("$t9")
-                label_map = {0: "A", 1: "B", 2: "Unknown"}
+                class_names = getattr(self.neural_ip, "class_names", [])
+                label_map = {idx: name for idx, name in enumerate(class_names)}
                 print(f"Final classification: {label_map.get(result, result)}")
         elif instr == "ADDI":
             rd = parts[1].rstrip(",")


### PR DESCRIPTION
## Summary
- Dynamically map neural IP class IDs to names in CPU HALT instruction
- Fallback to numeric class ID when no class name is available

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68952928cfec8325aea7bc10b289cd64