### PR TITLE
Include class names in dataset loading and CPU output

### DIFF
--- a/synapse/hardware/cpu.py
+++ b/synapse/hardware/cpu.py
@@ -73,7 +73,10 @@ class CPU:
             self.running = False
             if self.neural_ip.last_result is not None:
                 result = self.get_reg("$t9")
-                label_map = {0: "A", 1: "B", 2: "Unknown"}
+                label_map = {
+                    idx: name
+                    for idx, name in enumerate(getattr(self.neural_ip, "class_names", []) or [])
+                }
                 print(f"Final classification: {label_map.get(result, result)}")
         elif instr == "ADDI":
             rd = parts[1].rstrip(",")

--- a/synapse/models/redundant_ip.py
+++ b/synapse/models/redundant_ip.py
@@ -52,7 +52,8 @@ class RedundantNeuralIP:
         self._argmax: Dict[int, int] = {}
         self.vote_history: List[int] = []
         self.train_data_dir = train_data_dir
-        self._cached_dataset: tuple[torch.Tensor, torch.Tensor] | None = None
+        self.class_names: list[str] | None = None
+        self._cached_dataset: tuple[torch.Tensor, torch.Tensor, list[str]] | None = None
         # Metrics and figures generated during training keyed by ANN ID
         self.metrics_by_ann: Dict[int, Dict[str, float]] = {}
         self.figures_by_ann: Dict[int, List] = {}
@@ -134,7 +135,7 @@ class RedundantNeuralIP:
             }
 
         with open(json_path, "w", encoding="utf-8") as f:
-            json.dump({"anns": project}, f, indent=2)
+            json.dump({"anns": project, "class_names": self.class_names or []}, f, indent=2)
 
     # ------------------------------------------------------------------
     # CONFIG_ANN helpers
@@ -169,7 +170,7 @@ class RedundantNeuralIP:
         dataset = self._load_dataset()
         if dataset is None:
             return
-        X, y = dataset
+        X, y, _ = dataset
 
         # Update only the epoch count; GA-tuned learning rate and batch size are preserved
         ann.hp = replace(ann.hp, epochs=epochs)
@@ -220,7 +221,7 @@ class RedundantNeuralIP:
         dataset = self._load_dataset()
         if dataset is None:
             return
-        X, y = dataset
+        X, y, _ = dataset
 
         best_hp, best_ann = genetic_search(
             X,
@@ -240,14 +241,20 @@ class RedundantNeuralIP:
                 return None
             data_path = Path(self.train_data_dir) / "data.npy"
             labels_path = Path(self.train_data_dir) / "labels.npy"
-            if not data_path.exists() or not labels_path.exists():
-                X, y = load_vehicle_dataset(self.train_data_dir, hp.image_size)
+            classes_path = Path(self.train_data_dir) / "classes.json"
+            if not data_path.exists() or not labels_path.exists() or not classes_path.exists():
+                X, y, class_names = load_vehicle_dataset(self.train_data_dir, hp.image_size)
                 np.save(data_path, X.numpy())
                 np.save(labels_path, y.numpy())
+                with open(classes_path, "w", encoding="utf-8") as fh:
+                    json.dump(class_names, fh)
             else:
                 X = torch.from_numpy(np.load(data_path).astype(np.float32))
                 y = torch.from_numpy(np.load(labels_path).astype(np.int64))
-            hp.num_classes = int(torch.unique(y).numel())
-            self._cached_dataset = (X, y)
+                with open(classes_path, "r", encoding="utf-8") as fh:
+                    class_names = json.load(fh)
+            hp.num_classes = len(class_names)
+            self.class_names = class_names
+            self._cached_dataset = (X, y, class_names)
         return self._cached_dataset
 

--- a/synapsex/image_processing.py
+++ b/synapsex/image_processing.py
@@ -149,7 +149,7 @@ def preprocess_vehicle_image(
 
 def load_vehicle_dataset(
     root_dir: str, target_size: int = 28, rotate: bool = True
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, list[str]]:
     """Load vehicle images from class-named subdirectories.
 
     Parameters
@@ -165,9 +165,10 @@ def load_vehicle_dataset(
 
     Returns
     -------
-    X, y:
-        ``X`` is a tensor of flattened images and ``y`` contains integer class
-        labels.
+    X, y, class_names:
+        ``X`` is a tensor of flattened images, ``y`` contains integer class
+        labels and ``class_names`` lists the class directory names in index
+        order.
     """
 
     root = Path(root_dir)
@@ -199,7 +200,7 @@ def load_vehicle_dataset(
         raise ValueError("No images found in dataset")
     X = torch.stack(images)
     y = torch.tensor(labels, dtype=torch.long)
-    return X, y
+    return X, y, class_names
 
 
 def load_process_shape_image(

--- a/tests/test_num_classes.py
+++ b/tests/test_num_classes.py
@@ -45,7 +45,7 @@ def test_num_classes_updates_and_predictions_in_range(tmp_path):
         ip.run_instruction("CONFIG_ANN 0 FINALIZE")
         ip.run_instruction("TRAIN_ANN 0 1")
         assert hp.num_classes == 2
-        X, _ = ip._load_dataset()
+        X, _, _ = ip._load_dataset()
         probs = ip.ann_map[0].predict(X)
         assert probs.shape[1] == 2
         assert int(probs.argmax(dim=1).max().item()) <= 1

--- a/tests/test_save_project.py
+++ b/tests/test_save_project.py
@@ -15,6 +15,7 @@ def test_save_project(tmp_path):
     json_path = tmp_path / "project.json"
     ip.save_project(str(json_path), "test_weights")
     data = json.loads(json_path.read_text())
+    assert data["class_names"] == []
     assert "0" in data["anns"]
     ann_data = data["anns"]["0"]
     weight_file = tmp_path / ann_data["weights"]

--- a/tests/test_vehicle_dataset.py
+++ b/tests/test_vehicle_dataset.py
@@ -35,13 +35,15 @@ def _prepare_dataset(tmp_path):
 
 def test_load_vehicle_dataset(tmp_path):
     _prepare_dataset(tmp_path)
-    X, y = load_vehicle_dataset(tmp_path, target_size=8)
+    X, y, names = load_vehicle_dataset(tmp_path, target_size=8)
     assert X.shape == (144, 64)
     assert torch.bincount(y).tolist() == [72, 72]
+    assert names == ["car", "truck"]
 
 
 def test_load_vehicle_dataset_no_rotate(tmp_path):
     _prepare_dataset(tmp_path)
-    X, y = load_vehicle_dataset(tmp_path, target_size=8, rotate=False)
+    X, y, names = load_vehicle_dataset(tmp_path, target_size=8, rotate=False)
     assert X.shape == (2, 64)
     assert y.tolist() == [0, 1]
+    assert names == ["car", "truck"]


### PR DESCRIPTION
## Summary
- Return class name list from `load_vehicle_dataset` and persist it with training data.
- Cache and expose dataset class names in `RedundantNeuralIP`, saving them with project metadata.
- Map final CPU classifications using neural IP class names instead of hard-coded values.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68952947dd5083258672bfc29646b873