### PR TITLE
Add majority vote operation to neural IP

### DIFF
--- a/synapse/models/redundant_ip.py
+++ b/synapse/models/redundant_ip.py
@@ -81,6 +81,8 @@ class RedundantNeuralIP:
             if len(tokens) > 1:
                 ann_id = int(tokens[1])
                 result = self._argmax.get(ann_id, 0)
+        elif op == "MAJORITY_VOTE":
+            result = self._majority_vote()
         elif op == "SAVE_ALL":
             prefix = tokens[1] if len(tokens) > 1 else "weights"
             for ann_id, ann in self.ann_map.items():
@@ -206,6 +208,14 @@ class RedundantNeuralIP:
         self.vote_history.append(result)
         print(f"ANN {ann_id} prediction: {result}")
         return result
+
+    def _majority_vote(self) -> int:
+        """Return the class ID with the highest vote from cached argmaxes."""
+        preds = list(self._argmax.values())
+        if not preds:
+            return 0
+        counts = np.bincount(preds, minlength=hp.num_classes)
+        return int(counts.argmax())
 
     # ------------------------------------------------------------------
     # TUNE_GA helpers

--- a/tests/test_classification_asm.py
+++ b/tests/test_classification_asm.py
@@ -14,7 +14,7 @@ from synapsex.config import hp
 
 class MinimalNeuralIP(RedundantNeuralIP):
     class DummyANN:
-        def __init__(self, pred, num_classes: int = 3):
+        def __init__(self, pred: int, num_classes: int):
             self.pred = pred
             self.hp = SimpleNamespace(image_size=1, num_classes=num_classes)
 
@@ -29,11 +29,11 @@ class MinimalNeuralIP(RedundantNeuralIP):
         def load(self, path):
             pass
 
-    def __init__(self):
+    def __init__(self, num_classes: int = 3, stub_preds=None):
         super().__init__()
-        hp.num_classes = 3
-        self.class_names = ["a", "b", "c"]
-        self.stub_preds = {0: 0, 1: 1, 2: 1}
+        hp.num_classes = num_classes
+        self.class_names = [str(i) for i in range(num_classes)]
+        self.stub_preds = stub_preds or {0: 0, 1: 1, 2: 1}
 
     def _config_ann(self, tokens):
         if len(tokens) < 2:
@@ -41,7 +41,7 @@ class MinimalNeuralIP(RedundantNeuralIP):
         ann_id = int(tokens[0])
         if tokens[1] == "FINALIZE":
             pred = self.stub_preds[ann_id]
-            self.ann_map[ann_id] = self.DummyANN(pred)
+            self.ann_map[ann_id] = self.DummyANN(pred, hp.num_classes)
 
 
 def test_classification_asm_majority(tmp_path):
@@ -65,6 +65,24 @@ def test_classification_asm_majority(tmp_path):
     preds = [soc.memory.read(base + i) for i in range(3)]
     assert preds == [0, 1, 1]
 
-    # Final majority vote computed in assembly
+    # Final majority vote computed by neural IP
     assert soc.cpu.get_reg("$t9") == 1
+
+
+def test_classification_majority_over_16(tmp_path):
+    asm_path = pathlib.Path("asm/classification.asm")
+    lines = asm_path.read_text().splitlines()
+
+    stub_preds = {0: 5, 1: 17, 2: 17}
+    soc = SoC()
+    soc.neural_ip = MinimalNeuralIP(num_classes=20, stub_preds=stub_preds)
+    soc.cpu.neural_ip = soc.neural_ip
+    soc.load_assembly(lines)
+    soc.run(max_steps=500)
+
+    assert soc.cpu.get_reg("$s0") == 20
+    base = soc.data_map["ann_preds"] // 4
+    preds = [soc.memory.read(base + i) for i in range(3)]
+    assert preds == [5, 17, 17]
+    assert soc.cpu.get_reg("$t9") == 17
 


### PR DESCRIPTION
## Summary
- Compute majority class in Python via new `OP_NEUR MAJORITY_VOTE`
- Simplify classification assembly by delegating voting to the neural IP
- Add regression tests including datasets with more than 16 classes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6895296308e8832594afc487257770ff