### PR TITLE
Use training folder for class metadata

### DIFF
--- a/SynapseX.py
+++ b/SynapseX.py
@@ -303,7 +303,8 @@ class SynapseXGUI(tk.Tk):
         if not path:
             return
         processed = load_process_shape_image(path, angles=[0])[0]
-        soc = SoC()
+        train_dir = self.data_entry.get() or None
+        soc = SoC(train_data_dir=train_dir)
         base_addr_bytes = IMAGE_BUFFER_BASE_ADDR_BYTES
         for i, val in enumerate(processed):
             word = np.frombuffer(np.float32(val).tobytes(), dtype=np.uint32)[0]

--- a/tests/test_class_metadata.py
+++ b/tests/test_class_metadata.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+sys.path.append(os.getcwd())
+
+from synapse.models.redundant_ip import RedundantNeuralIP
+from synapsex.config import hp
+
+
+def test_class_names_from_training_dir(tmp_path):
+    (tmp_path / "car").mkdir()
+    (tmp_path / "bus").mkdir()
+    hp.num_classes = 0
+    ip = RedundantNeuralIP(train_data_dir=str(tmp_path))
+    ip.run_instruction("CONFIG_ANN 0 FINALIZE 0.2")
+    assert hp.num_classes == 2
+    assert ip.class_names == sorted(["car", "bus"])


### PR DESCRIPTION
## Summary
- load class count and names from training directory without reading dataset
- pass training directory to SoC when classifying images
- test that class metadata comes from dataset folders

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6895369210088325b457e15e5b402bd8