### PR TITLE
Display class names for ANN predictions

### DIFF
--- a/synapse/models/redundant_ip.py
+++ b/synapse/models/redundant_ip.py
@@ -236,7 +236,12 @@ class RedundantNeuralIP:
         )
         result = int(probs.argmax(dim=1)[0])
         self._argmax[ann_id] = result
-        print(f"ANN {ann_id} prediction: {result}")
+        label = (
+            self.class_names[result]
+            if self.class_names and 0 <= result < len(self.class_names)
+            else result
+        )
+        print(f"ANN {ann_id} prediction: {label}")
         return result
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Show human-readable class names for individual ANN predictions
- Capture stdout in classification test to verify class name output
- Confirm majority vote remains handled solely by assembly code

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6895501cf4b0832595f9da1f2de4553c