### PR TITLE
Display class names for ANN predictions

### DIFF
--- a/synapse/models/redundant_ip.py
+++ b/synapse/models/redundant_ip.py
@@ -92,7 +92,13 @@ class RedundantNeuralIP:
                 ann.save(f"{prefix}_{ann_id}.pt")
             meta_path = Path(f"{prefix}_meta.json")
             with open(meta_path, "w", encoding="utf-8") as f:
-                json.dump({"num_classes": hp.num_classes}, f)
+                json.dump(
+                    {
+                        "num_classes": hp.num_classes,
+                        "class_names": self.class_names or [],
+                    },
+                    f,
+                )
         elif op == "LOAD_ALL":
             prefix = tokens[1] if len(tokens) > 1 else "weights"
             for ann_id, ann in self.ann_map.items():
@@ -112,6 +118,8 @@ class RedundantNeuralIP:
                     with open(meta_path, "r", encoding="utf-8") as f:
                         data = json.load(f)
                     hp.num_classes = int(data.get("num_classes", hp.num_classes))
+                    if "class_names" in data:
+                        self.class_names = list(data["class_names"])
                 except (OSError, ValueError, json.JSONDecodeError):
                     pass
         elif op == "SAVE_PROJECT":
@@ -176,6 +184,8 @@ class RedundantNeuralIP:
                         with open(meta_path, "r", encoding="utf-8") as f:
                             data = json.load(f)
                         hp.num_classes = int(data.get("num_classes", hp.num_classes))
+                        if "class_names" in data:
+                            self.class_names = list(data["class_names"])
                     except (OSError, ValueError, json.JSONDecodeError):
                         pass
             if self.train_data_dir:
@@ -236,7 +246,12 @@ class RedundantNeuralIP:
         )
         result = int(probs.argmax(dim=1)[0])
         self._argmax[ann_id] = result
-        print(f"ANN {ann_id} prediction: {result}")
+        name = (
+            self.class_names[result]
+            if self.class_names and 0 <= result < len(self.class_names)
+            else result
+        )
+        print(f"ANN {ann_id} prediction: {name}")
         return result
 
     # ------------------------------------------------------------------

--- a/tests/test_infer_ann_output.py
+++ b/tests/test_infer_ann_output.py
@@ -1,0 +1,40 @@
+import io
+from contextlib import redirect_stdout
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+from synapse.models.redundant_ip import RedundantNeuralIP
+
+
+class DummyMem:
+    def read(self, addr):
+        return np.frombuffer(np.float32(0).tobytes(), dtype=np.uint32)[0]
+
+
+class DummyANN:
+    def __init__(self):
+        self.hp = SimpleNamespace(image_size=1)
+
+    def predict(self, X, mc_dropout: bool = False):
+        probs = torch.zeros((1, 2))
+        probs[0, 1] = 1.0
+        return probs
+
+    def save(self, path):
+        pass
+
+    def load(self, path):
+        pass
+
+
+def test_infer_ann_prints_class_name():
+    ip = RedundantNeuralIP()
+    ip.class_names = ["a", "b"]
+    ip.ann_map[0] = DummyANN()
+    mem = DummyMem()
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        ip.run_instruction("INFER_ANN 0", mem)
+    assert "ANN 0 prediction: b" in buf.getvalue()

--- a/tests/test_save_all_metadata.py
+++ b/tests/test_save_all_metadata.py
@@ -18,6 +18,7 @@ def test_save_all_writes_metadata(tmp_path):
         assert meta_path.exists()
         data = json.loads(meta_path.read_text())
         assert data["num_classes"] == 5
+        assert data["class_names"] == []
     finally:
         for k, v in orig.items():
             setattr(hp, k, v)


### PR DESCRIPTION
## Summary
- include class names in saved metadata and restore them when loading
- show each ANN's prediction as a class name during inference
- add tests for metadata and class name output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6895501cf4b0832595f9da1f2de4553c