### PR TITLE
Fail when LOAD_ALL weights missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ class-named directory.
 python SynapseX.py train data/vehicles
 ```
 
+### Loading saved weights
+
+The `LOAD_ALL` instruction expects weight files like `weights_0.pt` and an
+optional `weights_meta.json` in the working directory. Ensure these files exist
+before invoking `LOAD_ALL`; otherwise a `FileNotFoundError` will be raised.
+
 ### Preparing an annotated detection dataset
 
 `load_annotated_dataset` understands both COCO and YOLO layouts.

--- a/synapse/models/redundant_ip.py
+++ b/synapse/models/redundant_ip.py
@@ -29,6 +29,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Dict, List
 import json
+import logging
 
 import matplotlib
 matplotlib.use("Agg")
@@ -104,14 +105,15 @@ class RedundantNeuralIP:
             for ann_id, ann in self.ann_map.items():
                 weight_path = Path(f"{prefix}_{ann_id}.pt")
                 if not weight_path.exists():
-                    print(f"Weight file {weight_path} not found for ANN {ann_id}")
-                    continue
+                    msg = f"Weight file {weight_path} not found for ANN {ann_id}"
+                    logging.error(msg)
+                    raise FileNotFoundError(msg)
                 try:
                     ann.load(str(weight_path))
                 except Exception as e:  # pragma: no cover - propagate unexpected errors
                     msg = f"Failed to load weights for ANN {ann_id} from {weight_path}: {e}"
-                    print(msg)
-                    raise
+                    logging.error(msg)
+                    raise RuntimeError(msg) from e
             meta_path = Path(f"{prefix}_meta.json")
             if meta_path.exists():
                 try:

--- a/tests/test_classification_asm.py
+++ b/tests/test_classification_asm.py
@@ -60,6 +60,8 @@ def test_classification_asm_majority(tmp_path):
 
     meta_path = tmp_path / "trained_weights_meta.json"
     meta_path.write_text(json.dumps({"num_classes": 3}))
+    for i in range(3):
+        (tmp_path / f"trained_weights_{i}.pt").write_text("dummy")
 
     cwd = os.getcwd()
     os.chdir(tmp_path)

--- a/tests/test_load_all_weights.py
+++ b/tests/test_load_all_weights.py
@@ -1,0 +1,12 @@
+import pytest
+
+from synapse.models.redundant_ip import RedundantNeuralIP
+from synapsex.neural import PyTorchANN
+
+
+def test_load_all_raises_when_weights_missing(tmp_path):
+    ip = RedundantNeuralIP()
+    ip.ann_map[0] = PyTorchANN()
+    with pytest.raises(FileNotFoundError) as excinfo:
+        ip.run_instruction(f"LOAD_ALL {tmp_path / 'weights'}")
+    assert "ANN 0" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- raise informative errors when `LOAD_ALL` cannot find or load ANN weight files
- document required weight filenames
- test that missing weights trigger `FileNotFoundError`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6895a4dd848c8325bbcfc340d9e57189