### PR TITLE
Add assembly line enumeration and debugging

### DIFF
--- a/synapse/soc.py
+++ b/synapse/soc.py
@@ -40,8 +40,10 @@ class SoC:
 
     # ------------------------------------------------------------------
     def load_assembly(self, lines):
-        """Load assembly program and build label map."""
-        self.asm_program = lines[:]
+        """Load assembly program and build label map.
+
+        Lines are stored with 1-based line numbers to aid debugging."""
+        self.asm_program = list(enumerate(lines, start=1))
         self._preprocess_labels()
         self._preprocess_data()
         self.cpu.set_label_map(self.label_map)
@@ -49,7 +51,7 @@ class SoC:
 
     def _preprocess_labels(self):
         self.label_map = {}
-        for idx, line in enumerate(self.asm_program):
+        for idx, (_, line) in enumerate(self.asm_program):
             stripped = line.strip()
             if stripped.endswith(":"):
                 self.label_map[stripped[:-1]] = idx
@@ -58,7 +60,7 @@ class SoC:
         self.data_map = {}
         in_data = False
         addr = 0x4000
-        for line in self.asm_program:
+        for _, line in self.asm_program:
             stripped = line.strip()
             if stripped == ".data":
                 in_data = True
@@ -73,9 +75,17 @@ class SoC:
                 addr += size
 
     # ------------------------------------------------------------------
-    def run(self, max_steps=100):
+    def run(self, max_steps=100, debug: bool = False):
         for _ in range(max_steps):
             if self.cpu.running:
-                self.cpu.step(self.asm_program)
+                self.cpu.step(self.asm_program, debug=debug)
             else:
                 break
+
+    def debug_run(self, max_steps=100):
+        """Interactively step through the assembly program."""
+        for _ in range(max_steps):
+            if not self.cpu.running:
+                break
+            self.cpu.step(self.asm_program, debug=True)
+            input("Press Enter to continue...")

--- a/tests/test_asm_debug.py
+++ b/tests/test_asm_debug.py
@@ -1,0 +1,34 @@
+import io
+from contextlib import redirect_stdout
+import pytest
+import os
+import sys
+
+sys.path.append(os.getcwd())
+
+from synapse.soc import SoC
+
+
+def test_line_enumeration_and_debug_output():
+    lines = [
+        "ADDI $t0, $zero, 1",
+        "HALT",
+    ]
+    soc = SoC()
+    soc.load_assembly(lines)
+    assert soc.asm_program[0][0] == 1
+    assert soc.asm_program[1][0] == 2
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        soc.run(debug=True)
+    output = buf.getvalue()
+    assert "1: ADDI $t0, $zero, 1" in output
+    assert "2: HALT" in output
+
+
+def test_invalid_instruction_raises_error():
+    lines = ["FOO $t0, $t1, $t2"]
+    soc = SoC()
+    soc.load_assembly(lines)
+    with pytest.raises(ValueError):
+        soc.run()


### PR DESCRIPTION
## Summary
- number assembly lines and store them for debugging
- add step-by-step execution with optional interactive debugger
- validate instructions and raise errors on invalid or non-code lines
- cover assembly debugging with dedicated tests

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_b_6895a4ccfb708325a4e5152f0909c6b3