### PR TITLE
Add debug execution flag and GUI toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,11 @@ pip install -r requirements.txt
 python SynapseX.py gui                # launch the GUI
 python SynapseX.py train data/        # train on images in data/
 python SynapseX.py classify img.png   # classify an image
+python SynapseX.py classify img.png --debug  # include per-step debug output
 ```
+
+Pass `--debug` to print CPU state at each instruction or `--step` to advance
+interactively.
 
 ## Vehicle Classification and Object Detection
 


### PR DESCRIPTION
## Summary
- allow `SynapseX.py` to run in debug or step mode via new `--debug` and `--step` flags
- add a GUI checkbox to show per-instruction debug output
- document debug options in help text and README

## Testing
- `python -m py_compile SynapseX.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6895a9678d308325bbd5ee55d1c6c663