### PR TITLE
Align GUI classification with CLI

### DIFF
--- a/SynapseX.py
+++ b/SynapseX.py
@@ -307,8 +307,7 @@ class SynapseXGUI(tk.Tk):
         if not path:
             return
         processed = load_process_shape_image(path, angles=[0])[0]
-        train_dir = self.data_entry.get() or None
-        soc = SoC(train_data_dir=train_dir)
+        soc = SoC()
         base_addr_bytes = IMAGE_BUFFER_BASE_ADDR_BYTES
         for i, val in enumerate(processed):
             word = np.frombuffer(np.float32(val).tobytes(), dtype=np.uint32)[0]

--- a/synapse/models/redundant_ip.py
+++ b/synapse/models/redundant_ip.py
@@ -190,7 +190,7 @@ class RedundantNeuralIP:
                             self.class_names = list(data["class_names"])
                     except (OSError, ValueError, json.JSONDecodeError):
                         pass
-            if self.train_data_dir:
+            if self.train_data_dir and self.class_names is None:
                 self._load_class_metadata()
             dropout = float(tokens[2]) if len(tokens) >= 3 else hp.dropout
             hparams = HyperParameters(**{**hp.__dict__, "dropout": dropout})


### PR DESCRIPTION
## Summary
- Instantiate the SoC in the GUI image loader without a training data directory to match CLI inference
- Avoid reloading class metadata when class names are already present

## Testing
- `pytest`
- Simulated CLI vs GUI classification on the same image (both predicted class 1)


------
https://chatgpt.com/codex/tasks/task_b_6895b088c1dc8325b649610bed885414