### PR TITLE
Ensure class names saved with weights

### DIFF
--- a/synapse/models/redundant_ip.py
+++ b/synapse/models/redundant_ip.py
@@ -91,6 +91,8 @@ class RedundantNeuralIP:
             prefix = tokens[1] if len(tokens) > 1 else "weights"
             for ann_id, ann in self.ann_map.items():
                 ann.save(f"{prefix}_{ann_id}.pt")
+            if self.class_names is None:
+                self._load_class_metadata()
             meta_path = Path(f"{prefix}_meta.json")
             with open(meta_path, "w", encoding="utf-8") as f:
                 json.dump(
@@ -147,6 +149,8 @@ class RedundantNeuralIP:
 
         base = Path(json_path).resolve().parent
         project: Dict[str, Dict[str, object]] = {}
+        if self.class_names is None:
+            self._load_class_metadata()
 
         for ann_id, ann in self.ann_map.items():
             weight_file = f"{weight_prefix}_{ann_id}.pt"

--- a/tests/test_save_all_metadata.py
+++ b/tests/test_save_all_metadata.py
@@ -22,3 +22,22 @@ def test_save_all_writes_metadata(tmp_path):
     finally:
         for k, v in orig.items():
             setattr(hp, k, v)
+
+
+def test_save_all_includes_class_names(tmp_path):
+    (tmp_path / "car").mkdir()
+    (tmp_path / "bus").mkdir()
+    orig = hp.__dict__.copy()
+    try:
+        hp.num_classes = 0
+        ip = RedundantNeuralIP(train_data_dir=str(tmp_path))
+        ip.ann_map[0] = PyTorchANN()
+        prefix = tmp_path / "weights"
+        ip.run_instruction(f"SAVE_ALL {prefix}")
+        meta_path = tmp_path / "weights_meta.json"
+        data = json.loads(meta_path.read_text())
+        assert data["class_names"] == sorted(["car", "bus"])
+        assert data["num_classes"] == 2
+    finally:
+        for k, v in orig.items():
+            setattr(hp, k, v)


### PR DESCRIPTION
## Summary
- Preserve class metadata when saving ANN weights and projects
- Ensure saving all weights adds class names from the training directory
- Add regression test for class name metadata in weight saving

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6895b1f6361483258b859f438d84ec11