### PR TITLE
Align assembly line numbers with code font

### DIFF
--- a/SynapseX.py
+++ b/SynapseX.py
@@ -151,6 +151,7 @@ class SynapseXGUI(tk.Tk):
             borderwidth=0,
             highlightthickness=0,
             state="disabled",
+            font=("Consolas", 11),
         )
         self.asm_text = tk.Text(self.asm_frame, wrap="none", font=("Consolas", 11))
         self.asm_text.tag_configure("instr", foreground="#0066CC")


### PR DESCRIPTION
## Summary
- Use the same Consolas font for assembly line numbers as the code editor to keep lines aligned

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6895e4c5458c8325ad84f1dd95760a8c