### PR TITLE
Include image channels in ANN input size

### DIFF
--- a/synapse/models/redundant_ip.py
+++ b/synapse/models/redundant_ip.py
@@ -248,7 +248,9 @@ class RedundantNeuralIP:
             return
         addr_bytes = IMAGE_BUFFER_BASE_ADDR_BYTES
         addr = addr_bytes // 4
-        in_dim = ann.hp.image_size * ann.hp.image_size
+        in_dim = (
+            ann.hp.image_channels * ann.hp.image_size * ann.hp.image_size
+        )
         data: List[float] = []
         for i in range(in_dim):
             word = memory.read(addr + i)

--- a/tests/test_classification_asm.py
+++ b/tests/test_classification_asm.py
@@ -19,7 +19,9 @@ class MinimalNeuralIP(RedundantNeuralIP):
     class DummyANN:
         def __init__(self, pred, num_classes: int = 3):
             self.pred = pred
-            self.hp = SimpleNamespace(image_size=1, num_classes=num_classes)
+            self.hp = SimpleNamespace(
+                image_size=1, image_channels=1, num_classes=num_classes
+            )
 
         def predict(self, X, mc_dropout: bool = False):
             probs = torch.zeros((1, self.hp.num_classes))

--- a/tests/test_image_buffer.py
+++ b/tests/test_image_buffer.py
@@ -15,18 +15,19 @@ from synapse.hardware.memory import WishboneMemory
 def test_ann_receives_written_image_data():
     ip = RedundantNeuralIP()
     img_size = 2
-    pattern = np.arange(img_size * img_size, dtype=np.float32)
+    img_channels = 3
+    pattern = np.arange(img_channels * img_size * img_size, dtype=np.float32)
 
     class MockANN:
-        def __init__(self, size):
-            self.hp = SimpleNamespace(image_size=size)
+        def __init__(self, size, channels):
+            self.hp = SimpleNamespace(image_size=size, image_channels=channels)
             self.last_tensor = None
 
         def predict(self, tensor, mc_dropout=False):
             self.last_tensor = tensor
             return torch.zeros((1, 1))
 
-    ip.ann_map[0] = MockANN(img_size)
+    ip.ann_map[0] = MockANN(img_size, img_channels)
     memory = WishboneMemory()
     base_words = IMAGE_BUFFER_BASE_ADDR_BYTES // 4
     for i, val in enumerate(pattern):

--- a/tests/test_infer_ann_output.py
+++ b/tests/test_infer_ann_output.py
@@ -15,7 +15,7 @@ class DummyMem:
 
 class DummyANN:
     def __init__(self):
-        self.hp = SimpleNamespace(image_size=1)
+        self.hp = SimpleNamespace(image_size=1, image_channels=1)
 
     def predict(self, X, mc_dropout: bool = False):
         probs = torch.zeros((1, 2))


### PR DESCRIPTION
## Summary
- account for image channels when flattening image data during ANN inference
- update tests to supply `image_channels` and compute flattened image length accordingly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6895fde418f88325bcb012878c6d838d