### PR TITLE
Prevent GPU memory buildup during MC-dropout inference

### DIFF
--- a/synapsex/neural.py
+++ b/synapsex/neural.py
@@ -295,9 +295,10 @@ class PyTorchANN:
         X = self._format_input(X).to(self.device)
         if mc_dropout:
             self.model.train()  # enable dropout
-            preds = []
-            for _ in range(self.hp.mc_dropout_passes):
-                preds.append(self.model(X))
+            preds: List[torch.Tensor] = []
+            with torch.no_grad():
+                for _ in range(self.hp.mc_dropout_passes):
+                    preds.append(self.model(X).cpu())
             mean = torch.stack(preds).mean(0)
             return nn.functional.softmax(mean, dim=1).cpu()
         else:


### PR DESCRIPTION
## Summary
- Avoid gradient tracking during MC-dropout predictions
- Move MC-dropout outputs to CPU before stacking to save GPU memory

## Testing
- `python - <<'PY'
import torch, resource
from synapsex.neural import PyTorchANN

model = PyTorchANN()
X = torch.randn(1, model.hp.image_channels, model.hp.image_size, model.hp.image_size)

for i in range(5):
    model.predict(X, mc_dropout=True)
    mem_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
    print(i, mem_kb)
PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6895fe50742c83258506df96baac5218