### PR TITLE
Align classification pipeline with training and add evaluation routine

### DIFF
--- a/asm/classification.asm
+++ b/asm/classification.asm
@@ -28,13 +28,13 @@ ADD $s0, $zero, $t9            ; $s0 holds hp.num_classes
 OP_NEUR LOAD_ALL trained_weights
 
 ; (C) Perform Inference on the 3 Principal ANNs and fetch argmax directly
-OP_NEUR INFER_ANN 0 true 10
+OP_NEUR INFER_ANN 0
 OP_NEUR GET_ARGMAX 0
 SW $t9, ann_preds              ; store ANN0 prediction
-OP_NEUR INFER_ANN 1 true 10
+OP_NEUR INFER_ANN 1
 OP_NEUR GET_ARGMAX 1
 SW $t9, ann_preds+4            ; store ANN1 prediction
-OP_NEUR INFER_ANN 2 true 10
+OP_NEUR INFER_ANN 2
 OP_NEUR GET_ARGMAX 2
 SW $t9, ann_preds+8            ; store ANN2 prediction
 

--- a/tests/test_evaluate_with_assembly.py
+++ b/tests/test_evaluate_with_assembly.py
@@ -1,0 +1,90 @@
+import json
+import os
+import pathlib
+from types import SimpleNamespace
+
+import pytest
+import torch
+from PIL import Image
+
+from synapse.soc import SoC
+from synapse.models.redundant_ip import RedundantNeuralIP
+from synapsex.config import hp
+from SynapseX import evaluate_with_assembly
+
+
+class MinimalNeuralIP(RedundantNeuralIP):
+    class DummyANN:
+        def __init__(self, pred, num_classes):
+            self.pred = pred
+            self.hp = SimpleNamespace(image_size=hp.image_size, num_classes=num_classes)
+
+        def predict(self, X, mc_dropout: bool = False):
+            probs = torch.zeros((1, self.hp.num_classes))
+            probs[0, self.pred] = 1.0
+            return probs
+
+        def save(self, path):
+            pass
+
+        def load(self, path):
+            pass
+
+    def __init__(self):
+        super().__init__()
+        hp.num_classes = 0
+        self.class_names = ["a", "b"]
+        self.stub_preds = {0: 0, 1: 0, 2: 1}
+
+    def _config_ann(self, tokens):
+        if len(tokens) < 2:
+            return
+        ann_id = int(tokens[0])
+        if tokens[1] == "FINALIZE":
+            meta_prefix = tokens[3] if len(tokens) >= 4 else ""
+            if meta_prefix:
+                meta_path = pathlib.Path(f"{meta_prefix}_meta.json")
+                if meta_path.exists():
+                    data = json.loads(meta_path.read_text())
+                    hp.num_classes = data.get("num_classes", hp.num_classes)
+            pred = self.stub_preds[ann_id]
+            self.ann_map[ann_id] = self.DummyANN(pred, hp.num_classes)
+
+
+def create_image(path, color):
+    Image.new("L", (10, 10), color=color).save(path)
+
+
+def test_evaluate_with_assembly(tmp_path):
+    # create dataset
+    data_root = tmp_path / "data"
+    data_root.mkdir()
+    for cls, color in [("a", 0), ("b", 255)]:
+        d = data_root / cls
+        d.mkdir()
+        create_image(d / "img.png", color)
+
+    # dummy weights and metadata
+    meta = tmp_path / "trained_weights_meta.json"
+    meta.write_text(json.dumps({"num_classes": 2, "class_names": ["a", "b"]}))
+    for i in range(3):
+        (tmp_path / f"trained_weights_{i}.pt").write_text("dummy")
+
+    asm_src = pathlib.Path(__file__).resolve().parents[1] / "asm" / "classification.asm"
+    asm_dir = tmp_path / "asm"
+    asm_dir.mkdir()
+    (asm_dir / "classification.asm").write_text(asm_src.read_text())
+
+    soc = SoC()
+    soc.neural_ip = MinimalNeuralIP()
+    soc.cpu.neural_ip = soc.neural_ip
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        metrics, cm = evaluate_with_assembly(str(data_root), rotate=False, soc=soc)
+    finally:
+        os.chdir(cwd)
+
+    assert cm.shape == (2, 2)
+    assert metrics["accuracy"] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- Remove Monte Carlo dropout from the classification assembly to match training inference
- Process images for classification using the configured training image size
- Add `evaluate_with_assembly` and CLI `test` mode to run the classification assembly over a dataset and report metrics with a confusion matrix
- Cover the new evaluation helper with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6895fb7344048325918821954f6a89b5