### PR TITLE
Avoid gradient accumulation during MC dropout

### DIFF
--- a/synapsex/neural.py
+++ b/synapsex/neural.py
@@ -296,9 +296,11 @@ class PyTorchANN:
         if mc_dropout:
             self.model.train()  # enable dropout
             preds = []
-            for _ in range(self.hp.mc_dropout_passes):
-                preds.append(self.model(X))
+            with torch.no_grad():
+                for _ in range(self.hp.mc_dropout_passes):
+                    preds.append(self.model(X))
             mean = torch.stack(preds).mean(0)
+            self.model.eval()
             return nn.functional.softmax(mean, dim=1).cpu()
         else:
             self.model.eval()


### PR DESCRIPTION
## Summary
- Avoid gradient accumulation in `PyTorchANN.predict` by running MC-dropout passes under `torch.no_grad`
- Restore evaluation mode after dropout averaging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6895fe0bd47c83259eb5e4f49c35ce38