### PR TITLE
Align training and inference classification pathways

### DIFF
--- a/synapse/models/redundant_ip.py
+++ b/synapse/models/redundant_ip.py
@@ -261,11 +261,11 @@ class RedundantNeuralIP:
             word = memory.read(addr + i)
             data.append(np.frombuffer(np.uint32(word).tobytes(), dtype=np.float32)[0])
         X = np.array(data, dtype=np.float32).reshape(1, -1)
-        probs = ann.predict(
+        result_tensor = ann.predict_class(
             torch.from_numpy(X),
             mc_dropout=len(tokens) > 1 and tokens[1].lower() == "true",
         )
-        result = int(probs.argmax(dim=1)[0])
+        result = int(result_tensor[0])
         self._argmax[ann_id] = result
         name = (
             self.class_names[result]

--- a/tests/test_classification_asm.py
+++ b/tests/test_classification_asm.py
@@ -28,6 +28,9 @@ class MinimalNeuralIP(RedundantNeuralIP):
             probs[0, self.pred] = 1.0
             return probs
 
+        def predict_class(self, X, mc_dropout: bool = False):
+            return torch.tensor([self.pred])
+
         def save(self, path):
             pass
 

--- a/tests/test_evaluate_with_assembly.py
+++ b/tests/test_evaluate_with_assembly.py
@@ -24,6 +24,9 @@ class MinimalNeuralIP(RedundantNeuralIP):
             probs[0, self.pred] = 1.0
             return probs
 
+        def predict_class(self, X, mc_dropout: bool = False):
+            return torch.tensor([self.pred])
+
         def save(self, path):
             pass
 

--- a/tests/test_image_buffer.py
+++ b/tests/test_image_buffer.py
@@ -27,6 +27,10 @@ def test_ann_receives_written_image_data():
             self.last_tensor = tensor
             return torch.zeros((1, 1))
 
+        def predict_class(self, tensor, mc_dropout=False):
+            self.last_tensor = tensor
+            return torch.tensor([0])
+
     ip.ann_map[0] = MockANN(img_size, img_channels)
     memory = WishboneMemory()
     base_words = IMAGE_BUFFER_BASE_ADDR_BYTES // 4

--- a/tests/test_infer_ann_output.py
+++ b/tests/test_infer_ann_output.py
@@ -22,6 +22,9 @@ class DummyANN:
         probs[0, 1] = 1.0
         return probs
 
+    def predict_class(self, X, mc_dropout: bool = False):
+        return torch.tensor([1])
+
     def save(self, path):
         pass
 


### PR DESCRIPTION
## Summary
- Centralize classification logits and add `predict_class` helper so predictions use identical logic in training and inference
- Update ANN inference path to consume `predict_class` instead of manual argmax
- Adjust tests to accommodate new prediction API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68961a79d9d48325a99c79f0666c1d6a