### PR TITLE
Stop rotating images during inference

### DIFF
--- a/synapsex/classification.py
+++ b/synapsex/classification.py
@@ -51,13 +51,15 @@ def _load_asm_file(path: str | Path) -> list[str]:
 def classify_with_assembly(
     image_path: str,
     *,
-    angles: Iterable[int] = range(0, 360, 5),
+    angles: Iterable[int] = (0,),
     soc: SoC | None = None,
 ):
-    """Classify ``image_path`` running the assembly program on all rotations.
+    """Classify ``image_path`` using the assembly program.
 
-    The preprocessing exactly matches the training pipeline to ensure
-    consistent results.
+    By default the image is processed once without any rotation.  An
+    optional iterable of ``angles`` may be supplied to evaluate multiple
+    orientations, mirroring the data augmentation performed during
+    training.
     """
 
     soc = soc or SoC()


### PR DESCRIPTION
## Summary
- Disable image rotation during inference by default
- Clarify that additional angles may be supplied for optional rotation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68966dd7010483259196a15b68d17f91