### PR TITLE
Use edge and grayscale channels during training

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+

--- a/synapsex/classification.py
+++ b/synapsex/classification.py
@@ -18,10 +18,11 @@
 """Classification utilities driven by the assembly program.
 
 These helpers mirror the exact preprocessing pipeline used during
-training so that inference results remain consistent.  Images are
-converted to edge maps via :func:`synapsex.image_processing.process_shape_image`
-and fed into the `classification.asm` program to obtain predictions from
-the configured neural networks.
+training so that inference results remain consistent.  Each input image is
+converted to an edge map via :func:`synapsex.image_processing.process_shape_image`
+and stacked with the original grayscale version before being fed into the
+`classification.asm` program to obtain predictions from the configured
+neural networks.
 """
 
 from __future__ import annotations
@@ -64,7 +65,10 @@ def classify_with_assembly(
     asm_lines = _load_asm_file(Path("asm") / "classification.asm")
     soc.load_assembly(asm_lines)
     processed_list = load_process_shape_image(
-        str(image_path), target_size=hp.image_size, angles=angles
+        str(image_path),
+        target_size=hp.image_size,
+        angles=angles,
+        include_gray=True,
     )
     base_addr = IMAGE_BUFFER_BASE_ADDR_BYTES // 4
     preds: list[int] = []

--- a/synapsex/config.py
+++ b/synapsex/config.py
@@ -20,7 +20,9 @@ from dataclasses import dataclass
 @dataclass
 class HyperParameters:
     image_size: int = 28
-    image_channels: int = 1
+    # The classifier now consumes both an edge map and the original
+    # grayscale image, hence two input channels.
+    image_channels: int = 2
     num_classes: int = 3
     dropout: float = 0.2
     learning_rate: float = 1e-3

--- a/tests/test_class_metadata.py
+++ b/tests/test_class_metadata.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-sys.path.append(os.getcwd())
+sys.path.insert(0, os.getcwd())
 
 from synapse.models.redundant_ip import RedundantNeuralIP
 from synapsex.config import hp

--- a/tests/test_classification_asm.py
+++ b/tests/test_classification_asm.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 
 import torch
 
-sys.path.append(os.getcwd())
+sys.path.insert(0, os.getcwd())
 
 from synapse.soc import SoC
 from synapse.models.redundant_ip import RedundantNeuralIP
@@ -20,7 +20,7 @@ class MinimalNeuralIP(RedundantNeuralIP):
         def __init__(self, pred, num_classes: int = 3):
             self.pred = pred
             self.hp = SimpleNamespace(
-                image_size=1, image_channels=1, num_classes=num_classes
+                image_size=1, image_channels=2, num_classes=num_classes
             )
 
         def predict(self, X, mc_dropout: bool = False):

--- a/tests/test_classify_rotation.py
+++ b/tests/test_classify_rotation.py
@@ -27,7 +27,7 @@ import numpy as np
 import torch
 from PIL import Image
 
-sys.path.append(os.getcwd())
+sys.path.insert(0, os.getcwd())
 
 from SynapseX import classify_with_assembly  # noqa: E402
 from synapse.soc import SoC  # noqa: E402
@@ -40,7 +40,7 @@ class SeqNeuralIP(RedundantNeuralIP):
         def __init__(self, pred: int, num_classes: int = 2):
             self.pred = pred
             self.hp = SimpleNamespace(
-                image_size=1, image_channels=1, num_classes=num_classes
+                image_size=1, image_channels=2, num_classes=num_classes
             )
 
         def predict(self, _X, mc_dropout: bool = False):

--- a/tests/test_evaluate_with_assembly.py
+++ b/tests/test_evaluate_with_assembly.py
@@ -17,7 +17,9 @@ class MinimalNeuralIP(RedundantNeuralIP):
     class DummyANN:
         def __init__(self, pred, num_classes):
             self.pred = pred
-            self.hp = SimpleNamespace(image_size=hp.image_size, num_classes=num_classes)
+            self.hp = SimpleNamespace(
+                image_size=hp.image_size, image_channels=2, num_classes=num_classes
+            )
 
         def predict(self, X, mc_dropout: bool = False):
             probs = torch.zeros((1, self.hp.num_classes))

--- a/tests/test_image_buffer.py
+++ b/tests/test_image_buffer.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 import numpy as np
 import torch
 
-sys.path.append(os.getcwd())
+sys.path.insert(0, os.getcwd())
 
 from synapse.constants import IMAGE_BUFFER_BASE_ADDR_BYTES
 from synapse.models.redundant_ip import RedundantNeuralIP

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -22,7 +22,7 @@ import numpy as np
 import torch
 from PIL import Image
 
-sys.path.append(os.getcwd())
+sys.path.insert(0, os.getcwd())
 from synapsex.image_processing import (
     load_process_shape_image,
     load_annotated_dataset,
@@ -73,6 +73,8 @@ def test_preprocess_vehicle_image_matches_training(tmp_path):
     path = tmp_path / "vehicle.png"
     img.save(path)
     proc = preprocess_vehicle_image(str(path), target_size=16)
-    train_proc = load_process_shape_image(str(path), target_size=16, angles=[0])[0]
-    assert proc.shape == torch.Size([256])
+    train_proc = load_process_shape_image(
+        str(path), target_size=16, angles=[0], include_gray=True
+    )[0]
+    assert proc.shape == torch.Size([512])
     assert torch.allclose(proc, torch.from_numpy(train_proc), atol=1e-6)

--- a/tests/test_infer_ann_output.py
+++ b/tests/test_infer_ann_output.py
@@ -15,7 +15,7 @@ class DummyMem:
 
 class DummyANN:
     def __init__(self):
-        self.hp = SimpleNamespace(image_size=1, image_channels=1)
+        self.hp = SimpleNamespace(image_size=1, image_channels=2)
 
     def predict(self, X, mc_dropout: bool = False):
         probs = torch.zeros((1, 2))

--- a/tests/test_num_classes.py
+++ b/tests/test_num_classes.py
@@ -25,7 +25,7 @@ import pytest
 import torch
 from PIL import Image
 
-sys.path.append(os.getcwd())
+sys.path.insert(0, os.getcwd())
 from synapse.models.redundant_ip import RedundantNeuralIP
 from synapsex.config import hp
 

--- a/tests/test_transformer_classifier.py
+++ b/tests/test_transformer_classifier.py
@@ -23,7 +23,7 @@ import shutil
 import pytest
 import torch
 
-sys.path.append(os.getcwd())
+sys.path.insert(0, os.getcwd())
 from synapsex.models import TransformerClassifier
 
 

--- a/tests/test_vehicle_dataset.py
+++ b/tests/test_vehicle_dataset.py
@@ -22,7 +22,7 @@ import numpy as np
 import torch
 from PIL import Image
 
-sys.path.append(os.getcwd())
+sys.path.insert(0, os.getcwd())
 from synapsex.image_processing import load_vehicle_dataset
 
 
@@ -36,7 +36,7 @@ def _prepare_dataset(tmp_path):
 def test_load_vehicle_dataset(tmp_path):
     _prepare_dataset(tmp_path)
     X, y, names = load_vehicle_dataset(tmp_path, target_size=8)
-    assert X.shape == (144, 64)
+    assert X.shape == (144, 128)
     assert torch.bincount(y).tolist() == [72, 72]
     assert names == ["car", "truck"]
 
@@ -44,6 +44,6 @@ def test_load_vehicle_dataset(tmp_path):
 def test_load_vehicle_dataset_no_rotate(tmp_path):
     _prepare_dataset(tmp_path)
     X, y, names = load_vehicle_dataset(tmp_path, target_size=8, rotate=False)
-    assert X.shape == (2, 64)
+    assert X.shape == (2, 128)
     assert y.tolist() == [0, 1]
     assert names == ["car", "truck"]


### PR DESCRIPTION
## Summary
- stack edge-detected and grayscale images for training/inference
- load datasets with combined channels and update preprocessing/classification
- restrict pytest discovery to repo tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6896740d1c0483258be3c2cc84c21617